### PR TITLE
Add analytics reporting and health monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,15 @@ FRONTEND_BUILD_HOOK_TIMEOUT_MS=10000
 # Privacy-safe first-party website analytics.
 ANALYTICS_RETENTION_DAYS=395
 ANALYTICS_ALLOWED_ORIGINS=https://creativapoeta.com,https://www.creativapoeta.com,https://be.creativapoeta.com,https://fr.creativapoeta.com,https://rw.creativapoeta.com,https://nl.creativapoeta.com
+
+# Google Search Console read-only integration. Add the service-account email as
+# a user on every listed Search Console property. Prefer a base64-encoded key
+# in hosting environment variables to preserve line breaks safely.
+GSC_SERVICE_ACCOUNT_EMAIL=
+GSC_SERVICE_ACCOUNT_PRIVATE_KEY_BASE64=
+GSC_SITE_URLS=sc-domain:creativapoeta.com,sc-domain:creativapoeta.be
+GSC_CACHE_MINUTES=360
+
+# Secret used by an external uptime/cron monitor to call /api/health/monitor.
+ANALYTICS_MONITOR_SECRET=
+CRON_SECRET=

--- a/dist/app.js
+++ b/dist/app.js
@@ -7,6 +7,8 @@ const express_1 = __importDefault(require("express"));
 const dotenv_1 = __importDefault(require("dotenv"));
 const cors_1 = __importDefault(require("cors"));
 const routes_1 = __importDefault(require("./routes"));
+const errorHandler_1 = __importDefault(require("./middleware/errorHandler"));
+const analyticsServerMiddleware_1 = require("./middleware/analyticsServerMiddleware");
 dotenv_1.default.config();
 const app = (0, express_1.default)();
 // Allow all CORS requests - no restrictions
@@ -16,10 +18,15 @@ app.use((0, cors_1.default)({
     allowedHeaders: "*", // Allow all headers
     credentials: false, // Set to false when using origin: "*"
 }));
+app.use(analyticsServerMiddleware_1.analyticsServerMiddleware);
 app.use(express_1.default.json());
 app.get("/", (req, res) => {
     res.setHeader("X-CP-Commit", process.env.VERCEL_GIT_COMMIT_SHA || "local");
     res.send("Creativa Poeta Backend is running ✅");
 });
 app.use("/api", routes_1.default);
+app.use((_req, res) => {
+    res.status(404).json({ message: "Route not found." });
+});
+app.use(errorHandler_1.default);
 exports.default = app;

--- a/dist/controllers/analyticsIncidentController.js
+++ b/dist/controllers/analyticsIncidentController.js
@@ -1,0 +1,81 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.updateAnalyticsIncidentStatus = exports.evaluateAnalyticsIncidentsController = exports.getAnalyticsIncidentSummaryController = exports.listAnalyticsIncidents = void 0;
+const AnalyticsIncident_1 = __importDefault(require("../models/AnalyticsIncident"));
+const analyticsAnomalyService_1 = require("../services/analyticsAnomalyService");
+const allowedStatuses = ["open", "acknowledged", "resolved"];
+const listAnalyticsIncidents = async (req, res, next) => {
+    try {
+        const requestedStatus = String(req.query.status || "active");
+        const filter = requestedStatus === "all"
+            ? {}
+            : requestedStatus === "resolved"
+                ? { status: "resolved" }
+                : { status: { $in: ["open", "acknowledged"] } };
+        const incidents = await AnalyticsIncident_1.default.find(filter).sort({ lastDetectedAt: -1 }).limit(100).lean();
+        res.status(200).json({ incidents });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.listAnalyticsIncidents = listAnalyticsIncidents;
+const getAnalyticsIncidentSummaryController = async (_req, res, next) => {
+    try {
+        res.status(200).json({ metrics: await (0, analyticsAnomalyService_1.getAnalyticsIncidentSummary)() });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.getAnalyticsIncidentSummaryController = getAnalyticsIncidentSummaryController;
+const evaluateAnalyticsIncidentsController = async (_req, res, next) => {
+    try {
+        const incidents = await (0, analyticsAnomalyService_1.evaluateAnalyticsAnomalies)(true);
+        res.status(200).json({ incidents, metrics: await (0, analyticsAnomalyService_1.getAnalyticsIncidentSummary)() });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.evaluateAnalyticsIncidentsController = evaluateAnalyticsIncidentsController;
+const updateAnalyticsIncidentStatus = async (req, res, next) => {
+    var _a, _b;
+    try {
+        const status = String(((_a = req.body) === null || _a === void 0 ? void 0 : _a.status) || "");
+        if (!allowedStatuses.includes(status)) {
+            res.status(400).json({ message: "Invalid incident status." });
+            return;
+        }
+        const incident = await AnalyticsIncident_1.default.findById(req.params.id);
+        if (!incident) {
+            res.status(404).json({ message: "Analytics incident not found." });
+            return;
+        }
+        const actorEmail = String(((_b = req.user) === null || _b === void 0 ? void 0 : _b.email) || "").toLowerCase();
+        incident.status = status;
+        if (status === "acknowledged") {
+            incident.acknowledgedAt = new Date();
+            incident.acknowledgedByEmail = actorEmail;
+        }
+        if (status === "resolved") {
+            incident.resolvedAt = new Date();
+            incident.resolvedByEmail = actorEmail;
+        }
+        if (status === "open") {
+            incident.acknowledgedAt = undefined;
+            incident.acknowledgedByEmail = undefined;
+            incident.resolvedAt = undefined;
+            incident.resolvedByEmail = undefined;
+        }
+        await incident.save();
+        res.status(200).json({ incident });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.updateAnalyticsIncidentStatus = updateAnalyticsIncidentStatus;

--- a/dist/controllers/analyticsReportController.js
+++ b/dist/controllers/analyticsReportController.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAnalyticsRealtime = exports.getAnalyticsOverview = void 0;
+const analyticsReportService_1 = require("../services/analyticsReportService");
+const getAnalyticsOverview = async (req, res, next) => {
+    try {
+        const range = (0, analyticsReportService_1.resolveAnalyticsDateRange)(req.query);
+        const report = await (0, analyticsReportService_1.buildAnalyticsOverview)(range);
+        res.status(200).json(report);
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.getAnalyticsOverview = getAnalyticsOverview;
+const getAnalyticsRealtime = async (_req, res, next) => {
+    try {
+        res.status(200).json(await (0, analyticsReportService_1.getRealtimeAnalytics)());
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.getAnalyticsRealtime = getAnalyticsRealtime;

--- a/dist/controllers/healthController.js
+++ b/dist/controllers/healthController.js
@@ -1,0 +1,87 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.runMonitoringEvaluation = exports.getReadiness = exports.getLiveness = void 0;
+const crypto_1 = __importDefault(require("crypto"));
+const mongoose_1 = __importDefault(require("mongoose"));
+const AnalyticsServerMetric_1 = __importDefault(require("../models/AnalyticsServerMetric"));
+const analyticsAnomalyService_1 = require("../services/analyticsAnomalyService");
+const commit = () => process.env.VERCEL_GIT_COMMIT_SHA || "local";
+const getLiveness = (_req, res) => {
+    res.status(200).json({
+        status: "ok",
+        service: "creativa-poeta-backend",
+        timestamp: new Date().toISOString(),
+        commit: commit(),
+    });
+};
+exports.getLiveness = getLiveness;
+const getReadiness = async (_req, res, next) => {
+    var _a;
+    try {
+        let database = mongoose_1.default.connection.readyState === 1 ? "connected" : "disconnected";
+        if (database === "connected") {
+            try {
+                await ((_a = mongoose_1.default.connection.db) === null || _a === void 0 ? void 0 : _a.admin().ping());
+            }
+            catch {
+                database = "unavailable";
+            }
+        }
+        const ready = database === "connected";
+        const latestMetric = ready
+            ? await AnalyticsServerMetric_1.default.findOne().sort({ lastOccurredAt: -1 }).select("lastOccurredAt").lean()
+            : null;
+        res.status(ready ? 200 : 503).json({
+            status: ready ? "ready" : "degraded",
+            service: "creativa-poeta-backend",
+            database,
+            timestamp: new Date().toISOString(),
+            commit: commit(),
+            latestServerMetricAt: (latestMetric === null || latestMetric === void 0 ? void 0 : latestMetric.lastOccurredAt) || null,
+        });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.getReadiness = getReadiness;
+const safeEqual = (left, right) => {
+    const leftBuffer = Buffer.from(left);
+    const rightBuffer = Buffer.from(right);
+    return leftBuffer.length === rightBuffer.length && crypto_1.default.timingSafeEqual(leftBuffer, rightBuffer);
+};
+const runMonitoringEvaluation = async (req, res, next) => {
+    try {
+        const configuredSecret = String(process.env.ANALYTICS_MONITOR_SECRET || process.env.CRON_SECRET || "").trim();
+        const bearer = String(req.get("authorization") || "").replace(/^Bearer\s+/i, "").trim();
+        const providedSecret = String(req.get("x-cp-monitor-secret") || bearer).trim();
+        if (!configuredSecret) {
+            res.status(503).json({ status: "not_configured" });
+            return;
+        }
+        if (!providedSecret || !safeEqual(providedSecret, configuredSecret)) {
+            res.status(401).json({ status: "unauthorized" });
+            return;
+        }
+        const incidents = await (0, analyticsAnomalyService_1.evaluateAnalyticsAnomalies)(true);
+        const summary = await (0, analyticsAnomalyService_1.getAnalyticsIncidentSummary)();
+        res.status(summary.critical > 0 ? 503 : 200).json({
+            status: summary.critical > 0 ? "critical" : summary.warning > 0 ? "warning" : "healthy",
+            evaluatedAt: new Date().toISOString(),
+            summary,
+            incidents: incidents.map((incident) => ({
+                type: incident.type,
+                severity: incident.severity,
+                status: incident.status,
+                lastDetectedAt: incident.lastDetectedAt,
+            })),
+        });
+    }
+    catch (error) {
+        next(error);
+    }
+};
+exports.runMonitoringEvaluation = runMonitoringEvaluation;

--- a/dist/middleware/analyticsServerMiddleware.js
+++ b/dist/middleware/analyticsServerMiddleware.js
@@ -1,0 +1,97 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.analyticsServerMiddleware = void 0;
+const analyticsServerMetricService_1 = require("../services/analyticsServerMetricService");
+const botPattern = /(googlebot|bingbot|yandexbot|baiduspider|duckduckbot|facebookexternalhit|linkedinbot|twitterbot|slurp|semrushbot|ahrefsbot|mj12bot|crawler|spider|bot)/i;
+const normalizeRoute = (originalUrl) => {
+    const path = String(originalUrl || "/").split(/[?#]/)[0] || "/";
+    return path
+        .split("/")
+        .map((segment) => {
+        if (/^[a-f0-9]{24}$/i.test(segment))
+            return ":id";
+        if (/^[0-9]+$/.test(segment))
+            return ":id";
+        if (/^[a-f0-9-]{32,36}$/i.test(segment))
+            return ":id";
+        if (/^[A-Za-z0-9_-]{40,}$/.test(segment))
+            return ":token";
+        return segment.slice(0, 60);
+    })
+        .join("/")
+        .slice(0, 180);
+};
+const getBot = (req) => {
+    var _a;
+    const match = (_a = String(req.get("user-agent") || "").match(botPattern)) === null || _a === void 0 ? void 0 : _a[1];
+    return { isBot: Boolean(match), botName: (match === null || match === void 0 ? void 0 : match.toLowerCase()) || "none" };
+};
+const getCountry = (req) => String(req.get("x-vercel-ip-country") || "unknown").trim().slice(0, 4).toUpperCase();
+const formRoutes = {
+    "/api/contact/send": "contact",
+    "/api/project/send-inquiry": "project",
+    "/api/partnership-requests": "partnership",
+    "/api/job/apply": "job_application",
+    "/api/visibility-audit/technical": "visibility_audit",
+    "/api/visibility-audit/interpret": "visibility_audit",
+};
+const analyticsServerMiddleware = (req, res, next) => {
+    if (String(req.originalUrl || "").split(/[?#]/)[0] === "/api/health/live") {
+        next();
+        return;
+    }
+    const startedAt = process.hrtime.bigint();
+    res.once("finish", () => {
+        const durationMs = Number(process.hrtime.bigint() - startedAt) / 1000000;
+        const route = normalizeRoute(req.originalUrl);
+        const bot = getBot(req);
+        const country = getCountry(req);
+        const outcome = res.statusCode >= 500
+            ? "server_error"
+            : res.statusCode === 404
+                ? "not_found"
+                : res.statusCode >= 400
+                    ? "rejected"
+                    : "success";
+        void (0, analyticsServerMetricService_1.recordServerMetric)({
+            metricType: "api_request",
+            route,
+            method: req.method,
+            statusCode: res.statusCode,
+            outcome,
+            category: route.startsWith("/api/") ? "api" : "service",
+            country,
+            ...bot,
+            durationMs,
+        });
+        if (route === "/api/auth/login" && req.method === "POST") {
+            void (0, analyticsServerMetricService_1.recordServerMetric)({
+                metricType: "auth_attempt",
+                route,
+                method: req.method,
+                statusCode: res.statusCode,
+                outcome: res.statusCode >= 200 && res.statusCode < 300 ? "success" : "denied",
+                category: "admin_login",
+                country,
+                ...bot,
+                durationMs,
+            });
+        }
+        const formType = req.method === "POST" ? formRoutes[route] : undefined;
+        if (formType) {
+            void (0, analyticsServerMetricService_1.recordServerMetric)({
+                metricType: "form_submission",
+                route,
+                method: req.method,
+                statusCode: res.statusCode,
+                outcome: res.statusCode >= 200 && res.statusCode < 300 ? "success" : "failed",
+                category: formType,
+                country,
+                ...bot,
+                durationMs,
+            });
+        }
+    });
+    next();
+};
+exports.analyticsServerMiddleware = analyticsServerMiddleware;

--- a/dist/middleware/authMiddleware.js
+++ b/dist/middleware/authMiddleware.js
@@ -64,9 +64,7 @@ const authenticateUser = (req, res, next) => {
         next();
     }
     catch (err) {
-        console.error("Token verification error:", err.message);
-        console.error("Token:", token.substring(0, 50) + "...");
-        console.error("JWT_SECRET length:", JWT_SECRET ? JWT_SECRET.length : 0);
+        console.warn("Admin token verification failed:", (err === null || err === void 0 ? void 0 : err.name) || "unknown_error");
         if (err.name === "JsonWebTokenError") {
             res
                 .status(401)

--- a/dist/models/AnalyticsIncident.js
+++ b/dist/models/AnalyticsIncident.js
@@ -1,0 +1,70 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = __importStar(require("mongoose"));
+const AnalyticsIncidentSchema = new mongoose_1.Schema({
+    fingerprint: { type: String, required: true, unique: true, trim: true, maxlength: 120 },
+    type: { type: String, required: true, trim: true, maxlength: 80, index: true },
+    source: { type: String, required: true, trim: true, maxlength: 40, default: "server" },
+    severity: {
+        type: String,
+        required: true,
+        enum: ["info", "warning", "critical"],
+        index: true,
+    },
+    status: {
+        type: String,
+        required: true,
+        enum: ["open", "acknowledged", "resolved"],
+        default: "open",
+        index: true,
+    },
+    title: { type: String, required: true, trim: true, maxlength: 180 },
+    message: { type: String, required: true, trim: true, maxlength: 600 },
+    metric: { type: String, required: true, trim: true, maxlength: 80 },
+    currentValue: { type: Number, required: true, default: 0 },
+    baselineValue: { type: Number, required: true, default: 0 },
+    changePercent: { type: Number, required: true, default: 0 },
+    threshold: { type: Number, required: true, default: 0 },
+    occurrences: { type: Number, required: true, min: 1, default: 1 },
+    firstDetectedAt: { type: Date, required: true, default: Date.now },
+    lastDetectedAt: { type: Date, required: true, default: Date.now },
+    acknowledgedAt: { type: Date },
+    acknowledgedByEmail: { type: String, trim: true, lowercase: true, maxlength: 320 },
+    resolvedAt: { type: Date },
+    resolvedByEmail: { type: String, trim: true, lowercase: true, maxlength: 320 },
+}, { timestamps: true, versionKey: false });
+AnalyticsIncidentSchema.index({ status: 1, severity: 1, lastDetectedAt: -1 });
+exports.default = mongoose_1.default.model("AnalyticsIncident", AnalyticsIncidentSchema);

--- a/dist/models/AnalyticsServerMetric.js
+++ b/dist/models/AnalyticsServerMetric.js
@@ -1,0 +1,75 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = __importStar(require("mongoose"));
+const configuredRetentionDays = Number(process.env.ANALYTICS_RETENTION_DAYS || 395);
+const retentionDays = Number.isFinite(configuredRetentionDays)
+    ? Math.max(30, configuredRetentionDays)
+    : 395;
+const AnalyticsServerMetricSchema = new mongoose_1.Schema({
+    bucketStart: { type: Date, required: true },
+    metricType: {
+        type: String,
+        required: true,
+        enum: ["api_request", "auth_attempt", "form_submission", "spam_blocked"],
+    },
+    route: { type: String, required: true, trim: true, maxlength: 180, default: "unknown" },
+    method: { type: String, required: true, trim: true, maxlength: 12, default: "UNKNOWN" },
+    statusCode: { type: Number, required: true, min: 0, max: 999, default: 0 },
+    outcome: { type: String, required: true, trim: true, maxlength: 40, default: "unknown" },
+    category: { type: String, required: true, trim: true, maxlength: 80, default: "general" },
+    country: { type: String, required: true, trim: true, maxlength: 4, default: "unknown" },
+    isBot: { type: Boolean, required: true, default: false },
+    botName: { type: String, required: true, trim: true, maxlength: 40, default: "none" },
+    count: { type: Number, required: true, min: 0, default: 0 },
+    durationTotalMs: { type: Number, required: true, min: 0, default: 0 },
+    durationMaxMs: { type: Number, required: true, min: 0, default: 0 },
+    lastOccurredAt: { type: Date, required: true, default: Date.now },
+}, { versionKey: false });
+AnalyticsServerMetricSchema.index({
+    bucketStart: 1,
+    metricType: 1,
+    route: 1,
+    method: 1,
+    statusCode: 1,
+    outcome: 1,
+    category: 1,
+    country: 1,
+    isBot: 1,
+    botName: 1,
+}, { unique: true, name: "analytics_server_metric_bucket" });
+AnalyticsServerMetricSchema.index({ metricType: 1, bucketStart: -1 });
+AnalyticsServerMetricSchema.index({ bucketStart: 1 }, { expireAfterSeconds: retentionDays * 24 * 60 * 60 });
+exports.default = mongoose_1.default.model("AnalyticsServerMetric", AnalyticsServerMetricSchema);

--- a/dist/models/AnalyticsSession.js
+++ b/dist/models/AnalyticsSession.js
@@ -67,6 +67,8 @@ const AnalyticsSessionSchema = new mongoose_1.Schema({
 }, { versionKey: false });
 AnalyticsSessionSchema.index({ sessionId: 1 }, { unique: true });
 AnalyticsSessionSchema.index({ visitorId: 1, startedAt: -1 });
+AnalyticsSessionSchema.index({ startedAt: -1, isBot: 1 });
 AnalyticsSessionSchema.index({ lastSeenAt: -1 });
+AnalyticsSessionSchema.index({ lastSeenAt: -1, isBot: 1 });
 AnalyticsSessionSchema.index({ lastSeenAt: 1 }, { expireAfterSeconds: retentionSeconds });
 exports.default = mongoose_1.default.model("AnalyticsSession", AnalyticsSessionSchema);

--- a/dist/models/SearchConsoleCache.js
+++ b/dist/models/SearchConsoleCache.js
@@ -1,0 +1,46 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = __importStar(require("mongoose"));
+const SearchConsoleCacheSchema = new mongoose_1.Schema({
+    cacheKey: { type: String, required: true, unique: true, maxlength: 128 },
+    payload: { type: mongoose_1.Schema.Types.Mixed, required: true },
+    fetchedAt: { type: Date, required: true },
+    expiresAt: { type: Date, required: true },
+    deleteAfter: { type: Date, required: true },
+}, { versionKey: false });
+SearchConsoleCacheSchema.index({ expiresAt: 1 });
+SearchConsoleCacheSchema.index({ deleteAfter: 1 }, { expireAfterSeconds: 0 });
+exports.default = mongoose_1.default.model("SearchConsoleCache", SearchConsoleCacheSchema);

--- a/dist/routes/analyticsRoutes.js
+++ b/dist/routes/analyticsRoutes.js
@@ -7,6 +7,8 @@ const express_1 = __importDefault(require("express"));
 const analyticsController_1 = require("../controllers/analyticsController");
 const authMiddleware_1 = require("../middleware/authMiddleware");
 const permissionMiddleware_1 = require("../middleware/permissionMiddleware");
+const analyticsReportController_1 = require("../controllers/analyticsReportController");
+const analyticsIncidentController_1 = require("../controllers/analyticsIncidentController");
 const router = express_1.default.Router();
 const canReadAnalytics = (0, permissionMiddleware_1.authorizeAdminPermission)("analytics:read", [
     "admin_1",
@@ -15,4 +17,10 @@ const canReadAnalytics = (0, permissionMiddleware_1.authorizeAdminPermission)("a
 ]);
 router.post("/collect", analyticsController_1.collectAnalyticsEvents);
 router.get("/health", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsController_1.getAnalyticsCollectionHealth);
+router.get("/overview", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsReportController_1.getAnalyticsOverview);
+router.get("/realtime", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsReportController_1.getAnalyticsRealtime);
+router.get("/incidents", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsIncidentController_1.listAnalyticsIncidents);
+router.get("/incidents/summary", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsIncidentController_1.getAnalyticsIncidentSummaryController);
+router.post("/incidents/evaluate", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsIncidentController_1.evaluateAnalyticsIncidentsController);
+router.patch("/incidents/:id/status", authMiddleware_1.authenticateUser, canReadAnalytics, analyticsIncidentController_1.updateAnalyticsIncidentStatus);
 exports.default = router;

--- a/dist/routes/healthRoutes.js
+++ b/dist/routes/healthRoutes.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const healthController_1 = require("../controllers/healthController");
+const router = (0, express_1.Router)();
+router.get("/live", healthController_1.getLiveness);
+router.get("/ready", healthController_1.getReadiness);
+router.get("/monitor", healthController_1.runMonitoringEvaluation);
+exports.default = router;

--- a/dist/routes/index.js
+++ b/dist/routes/index.js
@@ -17,6 +17,7 @@ const adminNotificationRoutes_1 = __importDefault(require("./adminNotificationRo
 const internalMessageRoutes_1 = __importDefault(require("./internalMessageRoutes"));
 const partnershipRequestRoutes_1 = __importDefault(require("./partnershipRequestRoutes"));
 const analyticsRoutes_1 = __importDefault(require("./analyticsRoutes"));
+const healthRoutes_1 = __importDefault(require("./healthRoutes"));
 const router = express_1.default.Router();
 router.use("/auth", authRoutes_1.default);
 router.use("/blogs", BlogRoutes_1.default);
@@ -30,6 +31,7 @@ router.use("/jobs", CareerRoute_1.default);
 router.use("/visibility-audit", visibilityAuditRoutes_1.default);
 router.use("/partnership-requests", partnershipRequestRoutes_1.default);
 router.use("/analytics", analyticsRoutes_1.default);
+router.use("/health", healthRoutes_1.default);
 // Email test endpoint for debugging
 router.get("/test-email", emailTestController_1.testEmail);
 exports.default = router;

--- a/dist/server.js
+++ b/dist/server.js
@@ -7,13 +7,14 @@ exports.default = handler;
 const mongoose_1 = __importDefault(require("mongoose"));
 const app_1 = __importDefault(require("./app"));
 const MONGO_URI = process.env.MONGO_URI || "";
-if (!MONGO_URI) {
-    throw new Error("MONGO_URI environment variable is required");
-}
 let isConnected = false;
 async function connectDB() {
     if (isConnected)
         return;
+    if (!MONGO_URI) {
+        console.error("MONGO_URI environment variable is required for database-backed endpoints");
+        return;
+    }
     try {
         const db = await mongoose_1.default.connect(MONGO_URI, {
             serverSelectionTimeoutMS: 30000,
@@ -26,6 +27,9 @@ async function connectDB() {
     }
 }
 async function handler(req, res) {
-    await connectDB();
+    const requestPath = String(req.url || "").split("?")[0];
+    if (requestPath !== "/api/health/live") {
+        await connectDB();
+    }
     return (0, app_1.default)(req, res);
 }

--- a/dist/services/analyticsAnomalyService.js
+++ b/dist/services/analyticsAnomalyService.js
@@ -1,0 +1,318 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAnalyticsIncidentSummary = exports.evaluateAnalyticsAnomalies = void 0;
+const AnalyticsEvent_1 = __importDefault(require("../models/AnalyticsEvent"));
+const AnalyticsIncident_1 = __importDefault(require("../models/AnalyticsIncident"));
+const AnalyticsServerMetric_1 = __importDefault(require("../models/AnalyticsServerMetric"));
+let lastEvaluationAt = 0;
+let evaluationPromise = null;
+const round = (value, precision = 1) => {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+};
+const percentChange = (current, baseline) => {
+    if (baseline <= 0)
+        return current > 0 ? 100 : 0;
+    return round(((current - baseline) / baseline) * 100);
+};
+const serializeIncident = (incident) => ({
+    id: String(incident._id),
+    type: incident.type,
+    source: incident.source,
+    severity: incident.severity,
+    status: incident.status,
+    title: incident.title,
+    message: incident.message,
+    metric: incident.metric,
+    currentValue: incident.currentValue,
+    baselineValue: incident.baselineValue,
+    changePercent: incident.changePercent,
+    threshold: incident.threshold,
+    occurrences: incident.occurrences,
+    firstDetectedAt: incident.firstDetectedAt,
+    lastDetectedAt: incident.lastDetectedAt,
+    acknowledgedAt: incident.acknowledgedAt,
+    resolvedAt: incident.resolvedAt,
+});
+const aggregateWindow = async (from, to) => {
+    const rows = await AnalyticsServerMetric_1.default.aggregate([
+        { $match: { bucketStart: { $gte: from, $lt: to } } },
+        {
+            $group: {
+                _id: null,
+                requests: { $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$count", 0] } },
+                serverErrors: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                durationTotalMs: {
+                    $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$durationTotalMs", 0] },
+                },
+                authDenied: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                formAttempts: {
+                    $sum: { $cond: [{ $eq: ["$metricType", "form_submission"] }, "$count", 0] },
+                },
+                formFailures: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                spamBlocked: { $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] } },
+                botRequests: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+            },
+        },
+    ]);
+    const row = rows[0] || {};
+    return {
+        requests: Number(row.requests || 0),
+        serverErrors: Number(row.serverErrors || 0),
+        durationTotalMs: Number(row.durationTotalMs || 0),
+        authDenied: Number(row.authDenied || 0),
+        formAttempts: Number(row.formAttempts || 0),
+        formFailures: Number(row.formFailures || 0),
+        spamBlocked: Number(row.spamBlocked || 0),
+        botRequests: Number(row.botRequests || 0),
+    };
+};
+const detectOperationalIncidents = (current, baselineSevenDays) => {
+    const detected = [];
+    const dailyBaseline = Object.fromEntries(Object.entries(baselineSevenDays).map(([key, value]) => [key, Number(value || 0) / 7]));
+    const availability = current.requests > 0
+        ? ((current.requests - current.serverErrors) / current.requests) * 100
+        : 100;
+    const averageLatency = current.requests > 0 ? current.durationTotalMs / current.requests : 0;
+    const baselineLatency = dailyBaseline.requests > 0
+        ? dailyBaseline.durationTotalMs / dailyBaseline.requests
+        : 0;
+    const formFailureRate = current.formAttempts > 0
+        ? (current.formFailures / current.formAttempts) * 100
+        : 0;
+    if (current.requests >= 10 && availability < 99.5) {
+        detected.push({
+            fingerprint: "server:availability",
+            type: "availability_drop",
+            source: "server",
+            severity: availability < 98 ? "critical" : "warning",
+            title: "Observed API availability has dropped",
+            message: `${current.serverErrors} server error(s) were observed across ${current.requests} API requests in the last 24 hours.`,
+            metric: "observedAvailability",
+            currentValue: round(availability, 2),
+            baselineValue: 100,
+            changePercent: round(availability - 100, 2),
+            threshold: 99.5,
+        });
+    }
+    if (current.requests >= 10 &&
+        averageLatency > 1000 &&
+        (baselineLatency === 0 || averageLatency > baselineLatency * 1.8)) {
+        detected.push({
+            fingerprint: "server:latency",
+            type: "latency_spike",
+            source: "server",
+            severity: averageLatency > 2500 ? "critical" : "warning",
+            title: "API response time is unusually high",
+            message: `Average API response time reached ${Math.round(averageLatency)} ms during the last 24 hours.`,
+            metric: "averageResponseMs",
+            currentValue: round(averageLatency),
+            baselineValue: round(baselineLatency),
+            changePercent: percentChange(averageLatency, baselineLatency),
+            threshold: 1000,
+        });
+    }
+    if (current.serverErrors >= 3 &&
+        (dailyBaseline.serverErrors === 0 || current.serverErrors > dailyBaseline.serverErrors * 2)) {
+        detected.push({
+            fingerprint: "server:errors",
+            type: "server_error_spike",
+            source: "server",
+            severity: current.serverErrors >= 10 ? "critical" : "warning",
+            title: "Server errors are increasing",
+            message: `${current.serverErrors} HTTP 5xx responses were recorded in the last 24 hours.`,
+            metric: "serverErrors",
+            currentValue: current.serverErrors,
+            baselineValue: round(dailyBaseline.serverErrors),
+            changePercent: percentChange(current.serverErrors, dailyBaseline.serverErrors),
+            threshold: 3,
+        });
+    }
+    if (current.authDenied >= 5 &&
+        (dailyBaseline.authDenied === 0 || current.authDenied > dailyBaseline.authDenied * 2)) {
+        detected.push({
+            fingerprint: "security:auth-denied",
+            type: "auth_failure_spike",
+            source: "security",
+            severity: current.authDenied >= 20 ? "critical" : "warning",
+            title: "Unusual number of denied admin logins",
+            message: `${current.authDenied} admin login attempts were denied in the last 24 hours.`,
+            metric: "authDenied",
+            currentValue: current.authDenied,
+            baselineValue: round(dailyBaseline.authDenied),
+            changePercent: percentChange(current.authDenied, dailyBaseline.authDenied),
+            threshold: 5,
+        });
+    }
+    if (current.formAttempts >= 5 && current.formFailures >= 3 && formFailureRate >= 20) {
+        detected.push({
+            fingerprint: "forms:failures",
+            type: "form_failure_spike",
+            source: "forms",
+            severity: formFailureRate >= 50 || current.formFailures >= 10 ? "critical" : "warning",
+            title: "Public forms are failing unusually often",
+            message: `${current.formFailures} of ${current.formAttempts} server-side form submissions failed in the last 24 hours.`,
+            metric: "formFailureRate",
+            currentValue: round(formFailureRate),
+            baselineValue: dailyBaseline.formAttempts > 0
+                ? round((dailyBaseline.formFailures / dailyBaseline.formAttempts) * 100)
+                : 0,
+            changePercent: percentChange(current.formFailures, dailyBaseline.formFailures),
+            threshold: 20,
+        });
+    }
+    if (current.spamBlocked >= 10 &&
+        (dailyBaseline.spamBlocked === 0 || current.spamBlocked > dailyBaseline.spamBlocked * 3)) {
+        detected.push({
+            fingerprint: "mail:spam",
+            type: "spam_spike",
+            source: "mail",
+            severity: current.spamBlocked >= 50 ? "warning" : "info",
+            title: "Spam volume is above its usual level",
+            message: `${current.spamBlocked} new messages were filtered as spam during the last 24 hours.`,
+            metric: "spamBlocked",
+            currentValue: current.spamBlocked,
+            baselineValue: round(dailyBaseline.spamBlocked),
+            changePercent: percentChange(current.spamBlocked, dailyBaseline.spamBlocked),
+            threshold: 10,
+        });
+    }
+    if (current.botRequests >= 25 &&
+        (dailyBaseline.botRequests === 0 || current.botRequests > dailyBaseline.botRequests * 3)) {
+        detected.push({
+            fingerprint: "security:bots",
+            type: "bot_traffic_spike",
+            source: "security",
+            severity: current.botRequests >= 200 ? "warning" : "info",
+            title: "Automated traffic is above its usual level",
+            message: `${current.botRequests} bot requests were identified during the last 24 hours.`,
+            metric: "botRequests",
+            currentValue: current.botRequests,
+            baselineValue: round(dailyBaseline.botRequests),
+            changePercent: percentChange(current.botRequests, dailyBaseline.botRequests),
+            threshold: 25,
+        });
+    }
+    return detected;
+};
+const upsertDetectedIncidents = async (detected, now) => {
+    const fingerprints = detected.map((incident) => incident.fingerprint);
+    await Promise.all(detected.map(async (incident) => {
+        const existing = await AnalyticsIncident_1.default.findOne({ fingerprint: incident.fingerprint })
+            .select("status acknowledgedAt acknowledgedByEmail")
+            .lean();
+        const remainsAcknowledged = (existing === null || existing === void 0 ? void 0 : existing.status) === "acknowledged";
+        return AnalyticsIncident_1.default.updateOne({ fingerprint: incident.fingerprint }, {
+            $setOnInsert: { firstDetectedAt: now, occurrences: 0 },
+            $set: {
+                ...incident,
+                status: remainsAcknowledged ? "acknowledged" : "open",
+                lastDetectedAt: now,
+                resolvedAt: null,
+                resolvedByEmail: null,
+                acknowledgedAt: remainsAcknowledged ? existing.acknowledgedAt : null,
+                acknowledgedByEmail: remainsAcknowledged ? existing.acknowledgedByEmail : null,
+            },
+            $inc: { occurrences: 1 },
+        }, { upsert: true });
+    }));
+    await AnalyticsIncident_1.default.updateMany({
+        status: { $in: ["open", "acknowledged"] },
+        fingerprint: { $nin: fingerprints },
+        source: { $in: ["server", "security", "forms", "mail", "analytics"] },
+    }, { $set: { status: "resolved", resolvedAt: now, resolvedByEmail: "automatic-recovery" } });
+};
+const runEvaluation = async () => {
+    const now = new Date();
+    const currentFrom = new Date(now.getTime() - 24 * 60 * 60000);
+    const baselineFrom = new Date(currentFrom.getTime() - 7 * 24 * 60 * 60000);
+    const [current, baseline, lastBrowserEvent] = await Promise.all([
+        aggregateWindow(currentFrom, now),
+        aggregateWindow(baselineFrom, currentFrom),
+        AnalyticsEvent_1.default.findOne().sort({ receivedAt: -1 }).select("receivedAt").lean(),
+    ]);
+    const detected = detectOperationalIncidents(current, baseline);
+    if ((lastBrowserEvent === null || lastBrowserEvent === void 0 ? void 0 : lastBrowserEvent.receivedAt) &&
+        current.requests >= 10 &&
+        now.getTime() - new Date(lastBrowserEvent.receivedAt).getTime() > 24 * 60 * 60000) {
+        const silentHours = round((now.getTime() - new Date(lastBrowserEvent.receivedAt).getTime()) / 3600000);
+        detected.push({
+            fingerprint: "analytics:collection-stopped",
+            type: "analytics_collection_stopped",
+            source: "analytics",
+            severity: silentHours >= 72 ? "critical" : "warning",
+            title: "Browser analytics collection appears inactive",
+            message: `No consent-aware browser analytics event has been received for approximately ${silentHours} hours.`,
+            metric: "hoursSinceLastEvent",
+            currentValue: silentHours,
+            baselineValue: 0,
+            changePercent: 100,
+            threshold: 24,
+        });
+    }
+    await upsertDetectedIncidents(detected, now);
+    lastEvaluationAt = Date.now();
+    const incidents = await AnalyticsIncident_1.default.find({ status: { $in: ["open", "acknowledged"] } })
+        .sort({ severity: 1, lastDetectedAt: -1 })
+        .lean();
+    return incidents.map(serializeIncident);
+};
+const evaluateAnalyticsAnomalies = async (force = false) => {
+    if (!force && Date.now() - lastEvaluationAt < 5 * 60000) {
+        const incidents = await AnalyticsIncident_1.default.find({ status: { $in: ["open", "acknowledged"] } })
+            .sort({ lastDetectedAt: -1 })
+            .lean();
+        return incidents.map(serializeIncident);
+    }
+    if (!evaluationPromise) {
+        evaluationPromise = runEvaluation().finally(() => {
+            evaluationPromise = null;
+        });
+    }
+    return evaluationPromise;
+};
+exports.evaluateAnalyticsAnomalies = evaluateAnalyticsAnomalies;
+const getAnalyticsIncidentSummary = async () => {
+    const [open, critical, warning] = await Promise.all([
+        AnalyticsIncident_1.default.countDocuments({ status: { $in: ["open", "acknowledged"] } }),
+        AnalyticsIncident_1.default.countDocuments({ status: { $in: ["open", "acknowledged"] }, severity: "critical" }),
+        AnalyticsIncident_1.default.countDocuments({ status: { $in: ["open", "acknowledged"] }, severity: "warning" }),
+    ]);
+    return { open, critical, warning };
+};
+exports.getAnalyticsIncidentSummary = getAnalyticsIncidentSummary;

--- a/dist/services/analyticsReportService.js
+++ b/dist/services/analyticsReportService.js
@@ -1,0 +1,1006 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRealtimeAnalytics = exports.buildAnalyticsOverview = exports.resolveAnalyticsDateRange = void 0;
+const AnalyticsEvent_1 = __importDefault(require("../models/AnalyticsEvent"));
+const AnalyticsSession_1 = __importDefault(require("../models/AnalyticsSession"));
+const AnalyticsServerMetric_1 = __importDefault(require("../models/AnalyticsServerMetric"));
+const searchConsoleService_1 = require("./searchConsoleService");
+const analyticsAnomalyService_1 = require("./analyticsAnomalyService");
+const humanSessionFilter = {
+    $or: [{ isBot: false }, { isBot: { $exists: false } }],
+};
+const humanEventFilter = {
+    $or: [{ "device.isBot": false }, { "device.isBot": { $exists: false } }],
+};
+const round = (value, precision = 1) => {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+};
+const percentage = (value, total) => total > 0 ? round((value / total) * 100) : 0;
+const changePercentage = (current, previous) => {
+    if (previous === 0)
+        return current === 0 ? 0 : 100;
+    return round(((current - previous) / previous) * 100);
+};
+const resolveAnalyticsDateRange = (query) => {
+    const requestedDays = Math.min(395, Math.max(1, Number(query.days) || 30));
+    const customFrom = typeof query.from === "string" ? new Date(query.from) : null;
+    const customTo = typeof query.to === "string" ? new Date(query.to) : null;
+    const to = customTo && !Number.isNaN(customTo.getTime()) ? customTo : new Date();
+    if (customTo && !Number.isNaN(customTo.getTime()))
+        to.setHours(23, 59, 59, 999);
+    const earliestAllowed = new Date(to.getTime() - 395 * 24 * 60 * 60 * 1000);
+    let from = customFrom && !Number.isNaN(customFrom.getTime())
+        ? customFrom
+        : new Date(to.getTime() - requestedDays * 24 * 60 * 60 * 1000);
+    if (from < earliestAllowed)
+        from = earliestAllowed;
+    if (from > to)
+        from = new Date(to.getTime() - requestedDays * 24 * 60 * 60 * 1000);
+    if (customFrom && !Number.isNaN(customFrom.getTime()))
+        from.setHours(0, 0, 0, 0);
+    const duration = Math.max(1, to.getTime() - from.getTime());
+    const previousTo = new Date(from.getTime() - 1);
+    const previousFrom = new Date(previousTo.getTime() - duration);
+    const days = Math.max(1, Math.ceil(duration / (24 * 60 * 60 * 1000)));
+    return { from, to, previousFrom, previousTo, days };
+};
+exports.resolveAnalyticsDateRange = resolveAnalyticsDateRange;
+const getSummary = async (from, to, includeActive = false) => {
+    var _a, _b;
+    const sessionRange = { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter };
+    const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+    const [visitorIds, sessions, newVisitorIds, engagementRows, pageViews, conversions, convertedSessionIds, botSessions, errors, activeVisitorIds,] = await Promise.all([
+        AnalyticsSession_1.default.distinct("visitorId", sessionRange),
+        AnalyticsSession_1.default.countDocuments(sessionRange),
+        AnalyticsSession_1.default.distinct("visitorId", { ...sessionRange, isNewVisitor: true }),
+        AnalyticsSession_1.default.aggregate([
+            { $match: sessionRange },
+            {
+                $group: {
+                    _id: null,
+                    totalEngagementMs: { $sum: "$engagementMs" },
+                    engagedSessions: {
+                        $sum: {
+                            $cond: [
+                                { $or: [{ $gte: ["$engagementMs", 10000] }, { $gte: ["$pageViewCount", 2] }] },
+                                1,
+                                0,
+                            ],
+                        },
+                    },
+                },
+            },
+        ]),
+        AnalyticsEvent_1.default.countDocuments({ ...eventRange, eventType: "page_view" }),
+        AnalyticsEvent_1.default.countDocuments({ ...eventRange, eventType: "conversion" }),
+        AnalyticsEvent_1.default.distinct("sessionId", { ...eventRange, eventType: "conversion" }),
+        AnalyticsSession_1.default.countDocuments({ startedAt: { $gte: from, $lte: to }, isBot: true }),
+        AnalyticsEvent_1.default.countDocuments({
+            ...eventRange,
+            eventType: { $in: ["error", "api_error", "not_found"] },
+        }),
+        includeActive
+            ? AnalyticsSession_1.default.distinct("visitorId", {
+                lastSeenAt: { $gte: new Date(Date.now() - 5 * 60 * 1000) },
+                ...humanSessionFilter,
+            })
+            : Promise.resolve([]),
+    ]);
+    const visitors = visitorIds.length;
+    const newVisitors = newVisitorIds.length;
+    const engagedSessions = Number(((_a = engagementRows[0]) === null || _a === void 0 ? void 0 : _a.engagedSessions) || 0);
+    const totalEngagementMs = Number(((_b = engagementRows[0]) === null || _b === void 0 ? void 0 : _b.totalEngagementMs) || 0);
+    return {
+        visitors,
+        sessions,
+        pageViews,
+        activeVisitors: activeVisitorIds.length,
+        newVisitors,
+        returningVisitors: Math.max(0, visitors - newVisitors),
+        engagedSessions,
+        engagementRate: percentage(engagedSessions, sessions),
+        bounceRate: percentage(Math.max(0, sessions - engagedSessions), sessions),
+        averageEngagementSeconds: sessions > 0 ? round(totalEngagementMs / sessions / 1000) : 0,
+        conversions,
+        convertedSessions: convertedSessionIds.length,
+        conversionRate: percentage(convertedSessionIds.length, sessions),
+        botSessions,
+        errors,
+    };
+};
+const getTimeline = async (from, to) => {
+    const [sessionRows, eventRows] = await Promise.all([
+        AnalyticsSession_1.default.aggregate([
+            { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+            {
+                $group: {
+                    _id: { $dateToString: { format: "%Y-%m-%d", date: "$startedAt", timezone: "UTC" } },
+                    sessions: { $sum: 1 },
+                    visitors: { $addToSet: "$visitorId" },
+                    newVisitors: { $sum: { $cond: ["$isNewVisitor", 1, 0] } },
+                },
+            },
+            { $sort: { _id: 1 } },
+        ]),
+        AnalyticsEvent_1.default.aggregate([
+            { $match: { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter } },
+            {
+                $group: {
+                    _id: { $dateToString: { format: "%Y-%m-%d", date: "$occurredAt", timezone: "UTC" } },
+                    pageViews: { $sum: { $cond: [{ $eq: ["$eventType", "page_view"] }, 1, 0] } },
+                    conversions: { $sum: { $cond: [{ $eq: ["$eventType", "conversion"] }, 1, 0] } },
+                    errors: {
+                        $sum: {
+                            $cond: [{ $in: ["$eventType", ["error", "api_error", "not_found"]] }, 1, 0],
+                        },
+                    },
+                },
+            },
+            { $sort: { _id: 1 } },
+        ]),
+    ]);
+    const rows = new Map();
+    sessionRows.forEach((row) => {
+        rows.set(row._id, {
+            date: row._id,
+            visitors: row.visitors.length,
+            sessions: row.sessions,
+            newVisitors: row.newVisitors,
+            pageViews: 0,
+            conversions: 0,
+            errors: 0,
+        });
+    });
+    eventRows.forEach((row) => {
+        const current = rows.get(row._id) || {
+            date: row._id,
+            visitors: 0,
+            sessions: 0,
+            newVisitors: 0,
+            pageViews: 0,
+            conversions: 0,
+            errors: 0,
+        };
+        rows.set(row._id, {
+            ...current,
+            pageViews: row.pageViews,
+            conversions: row.conversions,
+            errors: row.errors,
+        });
+    });
+    const timeline = [];
+    const cursor = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()));
+    const lastDate = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()));
+    while (cursor <= lastDate) {
+        const date = cursor.toISOString().slice(0, 10);
+        timeline.push(rows.get(date) || {
+            date,
+            visitors: 0,
+            sessions: 0,
+            newVisitors: 0,
+            pageViews: 0,
+            conversions: 0,
+            errors: 0,
+        });
+        cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    return timeline;
+};
+const getBreakdown = async (field, from, to, limit = 12, extraMatch = {}) => {
+    const rows = await AnalyticsSession_1.default.aggregate([
+        { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter, ...extraMatch } },
+        { $group: { _id: { $ifNull: [`$${field}`, "Unknown"] }, count: { $sum: 1 } } },
+        { $sort: { count: -1 } },
+        { $limit: limit },
+    ]);
+    const total = rows.reduce((sum, row) => sum + Number(row.count || 0), 0);
+    return rows.map((row) => ({
+        name: String(row._id || "Unknown"),
+        count: Number(row.count || 0),
+        percentage: percentage(Number(row.count || 0), total),
+    }));
+};
+const getAudienceAndAcquisition = async (from, to) => {
+    const [countries, regions, locales, markets, devices, browsers, operatingSystems, sources, mediums, campaigns, referrers] = await Promise.all([
+        getBreakdown("country", from, to, 15),
+        getBreakdown("region", from, to, 15),
+        getBreakdown("locale", from, to, 10),
+        getBreakdown("market", from, to, 10),
+        getBreakdown("deviceType", from, to, 10),
+        getBreakdown("browser", from, to, 10),
+        getBreakdown("os", from, to, 10),
+        getBreakdown("trafficSource", from, to, 15),
+        getBreakdown("trafficMedium", from, to, 12),
+        getBreakdown("campaign", from, to, 15, { campaign: { $nin: [null, ""] } }),
+        getBreakdown("referrerHost", from, to, 15, { referrerHost: { $nin: [null, ""] } }),
+    ]);
+    return {
+        audience: { countries, regions, locales, markets, devices, browsers, operatingSystems },
+        acquisition: { sources, mediums, campaigns, referrers },
+    };
+};
+const getContent = async (from, to) => {
+    const [pageRows, engagementRows, exitRows, landingRows, scrollRows, sessionCount] = await Promise.all([
+        AnalyticsEvent_1.default.aggregate([
+            {
+                $match: {
+                    occurredAt: { $gte: from, $lte: to },
+                    eventType: "page_view",
+                    ...humanEventFilter,
+                },
+            },
+            {
+                $group: {
+                    _id: "$path",
+                    views: { $sum: 1 },
+                    visitors: { $addToSet: "$visitorId" },
+                    sessions: { $addToSet: "$sessionId" },
+                },
+            },
+            { $sort: { views: -1 } },
+            { $limit: 25 },
+        ]),
+        AnalyticsEvent_1.default.aggregate([
+            {
+                $match: {
+                    occurredAt: { $gte: from, $lte: to },
+                    eventType: "engagement",
+                    "properties.durationMs": { $gt: 0 },
+                    ...humanEventFilter,
+                },
+            },
+            { $group: { _id: "$path", engagementMs: { $sum: "$properties.durationMs" } } },
+        ]),
+        AnalyticsSession_1.default.aggregate([
+            { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+            {
+                $group: {
+                    _id: "$exitPath",
+                    exits: { $sum: 1 },
+                    visitors: { $addToSet: "$visitorId" },
+                },
+            },
+            { $sort: { exits: -1 } },
+        ]),
+        AnalyticsSession_1.default.aggregate([
+            { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+            {
+                $group: {
+                    _id: "$landingPath",
+                    sessions: { $sum: 1 },
+                    visitors: { $addToSet: "$visitorId" },
+                },
+            },
+            { $sort: { sessions: -1 } },
+            { $limit: 15 },
+        ]),
+        AnalyticsEvent_1.default.aggregate([
+            {
+                $match: {
+                    occurredAt: { $gte: from, $lte: to },
+                    eventType: "scroll",
+                    eventName: "scroll_depth",
+                    "properties.depth": { $in: [25, 50, 75, 90] },
+                    ...humanEventFilter,
+                },
+            },
+            {
+                $group: {
+                    _id: "$properties.depth",
+                    events: { $sum: 1 },
+                    sessions: { $addToSet: "$sessionId" },
+                    visitors: { $addToSet: "$visitorId" },
+                },
+            },
+            { $sort: { _id: 1 } },
+        ]),
+        AnalyticsSession_1.default.countDocuments({
+            startedAt: { $gte: from, $lte: to },
+            ...humanSessionFilter,
+        }),
+    ]);
+    const engagement = new Map(engagementRows.map((row) => [row._id, Number(row.engagementMs || 0)]));
+    const exits = new Map(exitRows.map((row) => [row._id, Number(row.exits || 0)]));
+    const pages = pageRows.map((row) => ({
+        path: row._id || "/",
+        views: Number(row.views || 0),
+        visitors: row.visitors.length,
+        sessions: row.sessions.length,
+        exits: exits.get(row._id) || 0,
+        exitRate: percentage(exits.get(row._id) || 0, row.sessions.length),
+        averageEngagementSeconds: row.sessions.length > 0 ? round((engagement.get(row._id) || 0) / row.sessions.length / 1000) : 0,
+    }));
+    return {
+        pages,
+        insights: {
+            landingPages: landingRows.map((row) => ({
+                path: row._id || "/",
+                sessions: Number(row.sessions || 0),
+                visitors: row.visitors.length,
+                percentage: percentage(Number(row.sessions || 0), sessionCount),
+            })),
+            exitPages: exitRows.slice(0, 15).map((row) => ({
+                path: row._id || "/",
+                exits: Number(row.exits || 0),
+                visitors: row.visitors.length,
+                percentage: percentage(Number(row.exits || 0), sessionCount),
+            })),
+            scrollDepth: scrollRows.map((row) => ({
+                depth: Number(row._id || 0),
+                events: Number(row.events || 0),
+                sessions: row.sessions.length,
+                visitors: row.visitors.length,
+                percentage: percentage(row.sessions.length, sessionCount),
+            })),
+        },
+    };
+};
+const getConversions = async (from, to) => {
+    const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+    const [rows, formStarts, formAttempts, attributionRows, formRows] = await Promise.all([
+        AnalyticsEvent_1.default.aggregate([
+            { $match: { ...eventRange, eventType: "conversion" } },
+            {
+                $group: {
+                    _id: { $ifNull: ["$properties.conversionType", "$eventName"] },
+                    count: { $sum: 1 },
+                    visitors: { $addToSet: "$visitorId" },
+                    sessions: { $addToSet: "$sessionId" },
+                },
+            },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsEvent_1.default.countDocuments({ ...eventRange, eventType: "form", eventName: "form_start" }),
+        AnalyticsEvent_1.default.countDocuments({
+            ...eventRange,
+            eventType: "form",
+            eventName: "form_submit_attempt",
+        }),
+        AnalyticsSession_1.default.aggregate([
+            { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+            {
+                $lookup: {
+                    from: AnalyticsEvent_1.default.collection.name,
+                    let: { currentSessionId: "$sessionId" },
+                    pipeline: [
+                        {
+                            $match: {
+                                eventType: "conversion",
+                                occurredAt: { $gte: from, $lte: to },
+                                ...humanEventFilter,
+                                $expr: { $eq: ["$sessionId", "$$currentSessionId"] },
+                            },
+                        },
+                        { $project: { _id: 1 } },
+                    ],
+                    as: "conversionEvents",
+                },
+            },
+            { $set: { conversionCount: { $size: "$conversionEvents" } } },
+            {
+                $facet: {
+                    sources: [
+                        {
+                            $group: {
+                                _id: { $ifNull: ["$trafficSource", "direct"] },
+                                sessions: { $sum: 1 },
+                                visitors: { $addToSet: "$visitorId" },
+                                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                                conversions: { $sum: "$conversionCount" },
+                            },
+                        },
+                        { $sort: { convertedSessions: -1, sessions: -1 } },
+                        { $limit: 12 },
+                    ],
+                    devices: [
+                        {
+                            $group: {
+                                _id: { $ifNull: ["$deviceType", "unknown"] },
+                                sessions: { $sum: 1 },
+                                visitors: { $addToSet: "$visitorId" },
+                                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                                conversions: { $sum: "$conversionCount" },
+                            },
+                        },
+                        { $sort: { convertedSessions: -1, sessions: -1 } },
+                        { $limit: 8 },
+                    ],
+                    countries: [
+                        {
+                            $group: {
+                                _id: { $ifNull: ["$country", "unknown"] },
+                                sessions: { $sum: 1 },
+                                visitors: { $addToSet: "$visitorId" },
+                                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                                conversions: { $sum: "$conversionCount" },
+                            },
+                        },
+                        { $sort: { convertedSessions: -1, sessions: -1 } },
+                        { $limit: 12 },
+                    ],
+                    landingPages: [
+                        {
+                            $group: {
+                                _id: { $ifNull: ["$landingPath", "/"] },
+                                sessions: { $sum: 1 },
+                                visitors: { $addToSet: "$visitorId" },
+                                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                                conversions: { $sum: "$conversionCount" },
+                            },
+                        },
+                        { $sort: { convertedSessions: -1, sessions: -1 } },
+                        { $limit: 12 },
+                    ],
+                },
+            },
+        ]),
+        AnalyticsEvent_1.default.aggregate([
+            {
+                $match: {
+                    ...eventRange,
+                    eventType: "form",
+                    eventName: { $in: ["form_start", "form_submit_attempt"] },
+                    "properties.form": { $nin: [null, ""] },
+                },
+            },
+            {
+                $group: {
+                    _id: { form: "$properties.form", eventName: "$eventName" },
+                    events: { $sum: 1 },
+                    sessions: { $addToSet: "$sessionId" },
+                },
+            },
+            { $sort: { events: -1 } },
+        ]),
+    ]);
+    const conversions = rows.map((row) => ({
+        name: String(row._id || "other"),
+        count: Number(row.count || 0),
+        visitors: row.visitors.length,
+        sessions: row.sessions.length,
+    }));
+    const mapAttribution = (attribution = []) => attribution.map((row) => ({
+        name: String(row._id || "unknown"),
+        sessions: Number(row.sessions || 0),
+        visitors: row.visitors.length,
+        convertedSessions: Number(row.convertedSessions || 0),
+        conversions: Number(row.conversions || 0),
+        conversionRate: percentage(Number(row.convertedSessions || 0), Number(row.sessions || 0)),
+    }));
+    const attribution = attributionRows[0] || {};
+    const forms = new Map();
+    formRows.forEach((row) => {
+        var _a, _b;
+        const form = String(((_a = row._id) === null || _a === void 0 ? void 0 : _a.form) || "unknown");
+        const item = forms.get(form) || {
+            form,
+            startEvents: 0,
+            attemptEvents: 0,
+            startedSessions: 0,
+            attemptedSessions: 0,
+            attemptRate: 0,
+        };
+        if (((_b = row._id) === null || _b === void 0 ? void 0 : _b.eventName) === "form_start") {
+            item.startEvents = Number(row.events || 0);
+            item.startedSessions = row.sessions.length;
+        }
+        else {
+            item.attemptEvents = Number(row.events || 0);
+            item.attemptedSessions = row.sessions.length;
+        }
+        forms.set(form, item);
+    });
+    const formItems = Array.from(forms.values())
+        .map((item) => ({
+        ...item,
+        attemptRate: percentage(item.attemptedSessions, item.startedSessions),
+    }))
+        .sort((left, right) => right.startedSessions - left.startedSessions);
+    return {
+        items: conversions,
+        funnel: {
+            formStarts,
+            formSubmitAttempts: formAttempts,
+            successfulConversions: conversions.reduce((sum, row) => sum + row.count, 0),
+        },
+        forms: formItems,
+        attribution: {
+            sources: mapAttribution(attribution.sources),
+            devices: mapAttribution(attribution.devices),
+            countries: mapAttribution(attribution.countries),
+            landingPages: mapAttribution(attribution.landingPages),
+        },
+    };
+};
+const percentile = (values, target) => {
+    if (values.length === 0)
+        return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    return sorted[Math.max(0, Math.ceil(sorted.length * target) - 1)];
+};
+const getPerformance = async (from, to) => {
+    const events = await AnalyticsEvent_1.default.find({
+        occurredAt: { $gte: from, $lte: to },
+        eventType: "web_vital",
+        ...humanEventFilter,
+    })
+        .select("properties.metricName properties.metricValue properties.metricRating device.type")
+        .sort({ occurredAt: -1 })
+        .limit(50000)
+        .lean();
+    const groups = new Map();
+    events.forEach((event) => {
+        var _a, _b, _c, _d;
+        const metric = String(((_a = event.properties) === null || _a === void 0 ? void 0 : _a.metricName) || "Unknown").toUpperCase();
+        const device = String(((_b = event.device) === null || _b === void 0 ? void 0 : _b.type) || "unknown");
+        const value = Number((_c = event.properties) === null || _c === void 0 ? void 0 : _c.metricValue);
+        if (!Number.isFinite(value))
+            return;
+        const key = `${metric}:${device}`;
+        const group = groups.get(key) || { metric, device, values: [], ratings: [] };
+        group.values.push(value);
+        group.ratings.push(String(((_d = event.properties) === null || _d === void 0 ? void 0 : _d.metricRating) || "unknown"));
+        groups.set(key, group);
+    });
+    const byDevice = Array.from(groups.values()).map((group) => ({
+        metric: group.metric,
+        device: group.device,
+        samples: group.values.length,
+        average: round(group.values.reduce((sum, value) => sum + value, 0) / group.values.length, 2),
+        p75: round(percentile(group.values, 0.75), 2),
+        good: group.ratings.filter((rating) => rating === "good").length,
+        needsImprovement: group.ratings.filter((rating) => rating === "needs-improvement").length,
+        poor: group.ratings.filter((rating) => rating === "poor").length,
+    }));
+    const overallGroups = new Map();
+    Array.from(groups.values()).forEach((group) => {
+        const current = overallGroups.get(group.metric) || { values: [], ratings: [] };
+        current.values.push(...group.values);
+        current.ratings.push(...group.ratings);
+        overallGroups.set(group.metric, current);
+    });
+    const overall = Array.from(overallGroups.entries()).map(([metric, group]) => ({
+        metric,
+        samples: group.values.length,
+        average: round(group.values.reduce((sum, value) => sum + value, 0) / group.values.length, 2),
+        p75: round(percentile(group.values, 0.75), 2),
+        good: group.ratings.filter((rating) => rating === "good").length,
+        needsImprovement: group.ratings.filter((rating) => rating === "needs-improvement").length,
+        poor: group.ratings.filter((rating) => rating === "poor").length,
+    }));
+    return { overall, byDevice, sampleLimitReached: events.length === 50000 };
+};
+const getServerBucketRange = (from, to) => {
+    const bucketFrom = new Date(from);
+    const startsInsideBucket = bucketFrom.getUTCMinutes() !== 0 ||
+        bucketFrom.getUTCSeconds() !== 0 ||
+        bucketFrom.getUTCMilliseconds() !== 0;
+    bucketFrom.setUTCMinutes(0, 0, 0);
+    if (startsInsideBucket)
+        bucketFrom.setUTCHours(bucketFrom.getUTCHours() + 1);
+    const bucketTo = new Date(to);
+    bucketTo.setUTCMinutes(0, 0, 0);
+    return { bucketFrom, bucketTo };
+};
+const getServerMetricTotals = async (from, to) => {
+    var _a, _b, _c, _d, _e;
+    const { bucketFrom, bucketTo } = getServerBucketRange(from, to);
+    const rows = await AnalyticsServerMetric_1.default.aggregate([
+        { $match: { bucketStart: { $gte: bucketFrom, $lte: bucketTo } } },
+        {
+            $group: {
+                _id: null,
+                serverErrors: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                authDenied: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                formFailures: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+                spamBlocked: {
+                    $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] },
+                },
+                botRequests: {
+                    $sum: {
+                        $cond: [
+                            { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+                            "$count",
+                            0,
+                        ],
+                    },
+                },
+            },
+        },
+    ]);
+    return {
+        serverErrors: Number(((_a = rows[0]) === null || _a === void 0 ? void 0 : _a.serverErrors) || 0),
+        authDenied: Number(((_b = rows[0]) === null || _b === void 0 ? void 0 : _b.authDenied) || 0),
+        formFailures: Number(((_c = rows[0]) === null || _c === void 0 ? void 0 : _c.formFailures) || 0),
+        spamBlocked: Number(((_d = rows[0]) === null || _d === void 0 ? void 0 : _d.spamBlocked) || 0),
+        botRequests: Number(((_e = rows[0]) === null || _e === void 0 ? void 0 : _e.botRequests) || 0),
+    };
+};
+const getServerHealth = async (from, to, previousFrom, previousTo) => {
+    const { bucketFrom, bucketTo } = getServerBucketRange(from, to);
+    const metricRange = { bucketStart: { $gte: bucketFrom, $lte: bucketTo } };
+    const [apiRows, statusRows, failingRouteRows, authRows, formRows, spamRows, botRows, timelineRows, currentTotals, previousTotals, lastMetric,] = await Promise.all([
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "api_request" } },
+            {
+                $group: {
+                    _id: null,
+                    requests: { $sum: "$count" },
+                    durationTotalMs: { $sum: "$durationTotalMs" },
+                    durationMaxMs: { $max: "$durationMaxMs" },
+                    successfulResponses: {
+                        $sum: { $cond: [{ $and: [{ $gte: ["$statusCode", 200] }, { $lt: ["$statusCode", 400] }] }, "$count", 0] },
+                    },
+                    clientErrors: {
+                        $sum: { $cond: [{ $and: [{ $gte: ["$statusCode", 400] }, { $lt: ["$statusCode", 500] }] }, "$count", 0] },
+                    },
+                    serverErrors: { $sum: { $cond: [{ $gte: ["$statusCode", 500] }, "$count", 0] } },
+                    notFoundResponses: { $sum: { $cond: [{ $eq: ["$statusCode", 404] }, "$count", 0] } },
+                    botRequests: { $sum: { $cond: ["$isBot", "$count", 0] } },
+                },
+            },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "api_request" } },
+            { $group: { _id: "$statusCode", count: { $sum: "$count" } } },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "api_request", statusCode: { $gte: 400 } } },
+            { $group: { _id: { route: "$route", statusCode: "$statusCode" }, count: { $sum: "$count" } } },
+            { $sort: { count: -1 } },
+            { $limit: 15 },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "auth_attempt" } },
+            { $group: { _id: { outcome: "$outcome", isBot: "$isBot" }, count: { $sum: "$count" } } },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "form_submission" } },
+            { $group: { _id: { category: "$category", outcome: "$outcome" }, count: { $sum: "$count" } } },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "spam_blocked" } },
+            { $group: { _id: "$category", count: { $sum: "$count" } } },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: { ...metricRange, metricType: "api_request", isBot: true } },
+            { $group: { _id: "$botName", count: { $sum: "$count" } } },
+            { $sort: { count: -1 } },
+            { $limit: 15 },
+        ]),
+        AnalyticsServerMetric_1.default.aggregate([
+            { $match: metricRange },
+            {
+                $group: {
+                    _id: { $dateToString: { format: "%Y-%m-%d", date: "$bucketStart", timezone: "UTC" } },
+                    requests: { $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$count", 0] } },
+                    serverErrors: {
+                        $sum: {
+                            $cond: [
+                                { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+                                "$count",
+                                0,
+                            ],
+                        },
+                    },
+                    notFound: {
+                        $sum: {
+                            $cond: [
+                                { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$statusCode", 404] }] },
+                                "$count",
+                                0,
+                            ],
+                        },
+                    },
+                    authDenied: {
+                        $sum: {
+                            $cond: [
+                                { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+                                "$count",
+                                0,
+                            ],
+                        },
+                    },
+                    formFailures: {
+                        $sum: {
+                            $cond: [
+                                { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+                                "$count",
+                                0,
+                            ],
+                        },
+                    },
+                    spamBlocked: { $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] } },
+                    botRequests: {
+                        $sum: {
+                            $cond: [
+                                { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+                                "$count",
+                                0,
+                            ],
+                        },
+                    },
+                },
+            },
+            { $sort: { _id: 1 } },
+        ]),
+        getServerMetricTotals(from, to),
+        getServerMetricTotals(previousFrom, previousTo),
+        AnalyticsServerMetric_1.default.findOne().sort({ lastOccurredAt: -1 }).select("lastOccurredAt").lean(),
+    ]);
+    const api = apiRows[0] || {};
+    const requests = Number(api.requests || 0);
+    const authSuccessful = authRows
+        .filter((row) => row._id.outcome === "success")
+        .reduce((sum, row) => sum + Number(row.count || 0), 0);
+    const authDenied = authRows
+        .filter((row) => row._id.outcome === "denied")
+        .reduce((sum, row) => sum + Number(row.count || 0), 0);
+    const authBotAttempts = authRows
+        .filter((row) => row._id.isBot)
+        .reduce((sum, row) => sum + Number(row.count || 0), 0);
+    const formItems = new Map();
+    formRows.forEach((row) => {
+        const type = String(row._id.category || "other");
+        const current = formItems.get(type) || { type, attempts: 0, successful: 0, failed: 0 };
+        const count = Number(row.count || 0);
+        current.attempts += count;
+        if (row._id.outcome === "success")
+            current.successful += count;
+        if (row._id.outcome === "failed")
+            current.failed += count;
+        formItems.set(type, current);
+    });
+    return {
+        api: {
+            requests,
+            successfulResponses: Number(api.successfulResponses || 0),
+            clientErrors: Number(api.clientErrors || 0),
+            serverErrors: Number(api.serverErrors || 0),
+            notFoundResponses: Number(api.notFoundResponses || 0),
+            botRequests: Number(api.botRequests || 0),
+            observedAvailability: requests > 0
+                ? round(((requests - Number(api.serverErrors || 0)) / requests) * 100, 2)
+                : 0,
+            averageResponseMs: requests > 0 ? round(Number(api.durationTotalMs || 0) / requests) : 0,
+            maximumResponseMs: round(Number(api.durationMaxMs || 0)),
+            statuses: statusRows.map((row) => ({ status: Number(row._id || 0), count: Number(row.count || 0) })),
+            failingRoutes: failingRouteRows.map((row) => ({
+                route: String(row._id.route || "unknown"),
+                status: Number(row._id.statusCode || 0),
+                count: Number(row.count || 0),
+            })),
+        },
+        auth: {
+            attempts: authSuccessful + authDenied,
+            successful: authSuccessful,
+            denied: authDenied,
+            botAttempts: authBotAttempts,
+        },
+        forms: {
+            attempts: Array.from(formItems.values()).reduce((sum, item) => sum + item.attempts, 0),
+            successful: Array.from(formItems.values()).reduce((sum, item) => sum + item.successful, 0),
+            failed: Array.from(formItems.values()).reduce((sum, item) => sum + item.failed, 0),
+            byType: Array.from(formItems.values()),
+        },
+        spam: {
+            blocked: spamRows.reduce((sum, row) => sum + Number(row.count || 0), 0),
+            byRule: spamRows.map((row) => ({ name: String(row._id || "other"), count: Number(row.count || 0) })),
+        },
+        bots: botRows.map((row) => ({ name: String(row._id || "unknown"), count: Number(row.count || 0) })),
+        timeline: timelineRows.map((row) => ({
+            date: row._id,
+            requests: Number(row.requests || 0),
+            serverErrors: Number(row.serverErrors || 0),
+            notFound: Number(row.notFound || 0),
+            authDenied: Number(row.authDenied || 0),
+            formFailures: Number(row.formFailures || 0),
+            spamBlocked: Number(row.spamBlocked || 0),
+            botRequests: Number(row.botRequests || 0),
+        })),
+        comparison: Object.fromEntries(Object.entries(currentTotals).map(([key, value]) => [
+            key,
+            changePercentage(Number(value || 0), Number(previousTotals[key] || 0)),
+        ])),
+        lastMetricAt: (lastMetric === null || lastMetric === void 0 ? void 0 : lastMetric.lastOccurredAt) || null,
+    };
+};
+const getHealth = async (from, to, previousFrom, previousTo) => {
+    const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+    const [errorRows, statusRows, botRows, lastEvent, server, incidents] = await Promise.all([
+        AnalyticsEvent_1.default.aggregate([
+            { $match: { ...eventRange, eventType: { $in: ["error", "api_error", "not_found"] } } },
+            { $group: { _id: "$eventName", count: { $sum: 1 } } },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsEvent_1.default.aggregate([
+            { $match: { ...eventRange, eventType: "api_error" } },
+            { $group: { _id: { $ifNull: ["$properties.statusCode", 0] }, count: { $sum: 1 } } },
+            { $sort: { count: -1 } },
+        ]),
+        AnalyticsSession_1.default.aggregate([
+            { $match: { startedAt: { $gte: from, $lte: to }, isBot: true } },
+            { $group: { _id: { $ifNull: ["$botName", "unknown"] }, count: { $sum: 1 } } },
+            { $sort: { count: -1 } },
+            { $limit: 15 },
+        ]),
+        AnalyticsEvent_1.default.findOne().sort({ receivedAt: -1 }).select("receivedAt eventName").lean(),
+        getServerHealth(from, to, previousFrom, previousTo),
+        (0, analyticsAnomalyService_1.evaluateAnalyticsAnomalies)(),
+    ]);
+    return {
+        errorsByType: errorRows.map((row) => ({ name: row._id, count: Number(row.count || 0) })),
+        apiErrorsByStatus: statusRows.map((row) => ({ status: Number(row._id || 0), count: Number(row.count || 0) })),
+        bots: botRows.map((row) => ({ name: row._id, count: Number(row.count || 0) })),
+        lastEventAt: (lastEvent === null || lastEvent === void 0 ? void 0 : lastEvent.receivedAt) || null,
+        server,
+        incidents,
+    };
+};
+const buildAnalyticsOverview = async (range) => {
+    const [summary, previousSummary, timeline, audienceAcquisition, content, conversions, performance, health, seo] = await Promise.all([
+        getSummary(range.from, range.to, true),
+        getSummary(range.previousFrom, range.previousTo),
+        getTimeline(range.from, range.to),
+        getAudienceAndAcquisition(range.from, range.to),
+        getContent(range.from, range.to),
+        getConversions(range.from, range.to),
+        getPerformance(range.from, range.to),
+        getHealth(range.from, range.to, range.previousFrom, range.previousTo),
+        (0, searchConsoleService_1.getSearchConsoleReport)(range.from, range.to),
+    ]);
+    const comparison = Object.fromEntries(Object.entries(summary)
+        .filter(([key]) => key !== "activeVisitors")
+        .map(([key, value]) => [
+        key,
+        changePercentage(Number(value || 0), Number(previousSummary[key] || 0)),
+    ]));
+    return {
+        range: {
+            from: range.from.toISOString(),
+            to: range.to.toISOString(),
+            previousFrom: range.previousFrom.toISOString(),
+            previousTo: range.previousTo.toISOString(),
+            days: range.days,
+        },
+        summary,
+        comparison,
+        timeline,
+        ...audienceAcquisition,
+        content: content.pages,
+        contentInsights: content.insights,
+        conversions,
+        performance,
+        health,
+        seo,
+    };
+};
+exports.buildAnalyticsOverview = buildAnalyticsOverview;
+const getRealtimeAnalytics = async () => {
+    var _a, _b;
+    const generatedAt = new Date();
+    const windowMinutes = 5;
+    const activeSince = new Date(generatedAt.getTime() - windowMinutes * 60000);
+    const [result] = await AnalyticsSession_1.default.aggregate([
+        {
+            $match: {
+                lastSeenAt: { $gte: activeSince, $lte: generatedAt },
+                ...humanSessionFilter,
+            },
+        },
+        {
+            $facet: {
+                summary: [
+                    {
+                        $group: {
+                            _id: null,
+                            visitors: { $addToSet: "$visitorId" },
+                            sessions: { $sum: 1 },
+                            newVisitors: {
+                                $addToSet: { $cond: ["$isNewVisitor", "$visitorId", null] },
+                            },
+                            lastActivityAt: { $max: "$lastSeenAt" },
+                        },
+                    },
+                ],
+                pages: [
+                    {
+                        $group: {
+                            _id: { $ifNull: ["$exitPath", "/"] },
+                            sessions: { $sum: 1 },
+                            visitors: { $addToSet: "$visitorId" },
+                        },
+                    },
+                    { $sort: { sessions: -1 } },
+                    { $limit: 10 },
+                ],
+                countries: [
+                    {
+                        $group: {
+                            _id: { $ifNull: ["$country", "unknown"] },
+                            sessions: { $sum: 1 },
+                            visitors: { $addToSet: "$visitorId" },
+                        },
+                    },
+                    { $sort: { sessions: -1 } },
+                    { $limit: 10 },
+                ],
+                devices: [
+                    {
+                        $group: {
+                            _id: { $ifNull: ["$deviceType", "unknown"] },
+                            sessions: { $sum: 1 },
+                            visitors: { $addToSet: "$visitorId" },
+                        },
+                    },
+                    { $sort: { sessions: -1 } },
+                    { $limit: 6 },
+                ],
+                sources: [
+                    {
+                        $group: {
+                            _id: { $ifNull: ["$trafficSource", "direct"] },
+                            sessions: { $sum: 1 },
+                            visitors: { $addToSet: "$visitorId" },
+                        },
+                    },
+                    { $sort: { sessions: -1 } },
+                    { $limit: 10 },
+                ],
+            },
+        },
+    ]);
+    const summary = ((_a = result === null || result === void 0 ? void 0 : result.summary) === null || _a === void 0 ? void 0 : _a[0]) || {};
+    const mapBreakdown = (rows = []) => rows.map((row) => ({
+        name: String(row._id || "unknown"),
+        sessions: Number(row.sessions || 0),
+        visitors: row.visitors.length,
+    }));
+    return {
+        generatedAt,
+        activeSince,
+        windowMinutes,
+        activeVisitors: ((_b = summary.visitors) === null || _b === void 0 ? void 0 : _b.length) || 0,
+        activeSessions: Number(summary.sessions || 0),
+        newVisitors: Array.isArray(summary.newVisitors)
+            ? summary.newVisitors.filter(Boolean).length
+            : 0,
+        lastActivityAt: summary.lastActivityAt || null,
+        pages: mapBreakdown(result === null || result === void 0 ? void 0 : result.pages),
+        countries: mapBreakdown(result === null || result === void 0 ? void 0 : result.countries),
+        devices: mapBreakdown(result === null || result === void 0 ? void 0 : result.devices),
+        sources: mapBreakdown(result === null || result === void 0 ? void 0 : result.sources),
+    };
+};
+exports.getRealtimeAnalytics = getRealtimeAnalytics;

--- a/dist/services/analyticsServerMetricService.js
+++ b/dist/services/analyticsServerMetricService.js
@@ -1,0 +1,49 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.recordServerMetric = void 0;
+const AnalyticsServerMetric_1 = __importDefault(require("../models/AnalyticsServerMetric"));
+const cleanDimension = (value, fallback, maxLength) => {
+    const cleaned = String(value || "")
+        .replace(/[\u0000-\u001f\u007f]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, maxLength);
+    return cleaned || fallback;
+};
+const getHourBucket = (value) => {
+    const bucket = new Date(value);
+    bucket.setUTCMinutes(0, 0, 0);
+    return bucket;
+};
+const recordServerMetric = async (input) => {
+    try {
+        const occurredAt = input.occurredAt || new Date();
+        const durationMs = Math.max(0, Math.min(3600000, Math.round(Number(input.durationMs) || 0)));
+        const dimensions = {
+            bucketStart: getHourBucket(occurredAt),
+            metricType: input.metricType,
+            route: cleanDimension(input.route, "unknown", 180),
+            method: cleanDimension(input.method, "UNKNOWN", 12).toUpperCase(),
+            statusCode: Math.max(0, Math.min(999, Math.round(Number(input.statusCode) || 0))),
+            outcome: cleanDimension(input.outcome, "unknown", 40).toLowerCase(),
+            category: cleanDimension(input.category, "general", 80).toLowerCase(),
+            country: cleanDimension(input.country, "unknown", 4).toUpperCase(),
+            isBot: Boolean(input.isBot),
+            botName: cleanDimension(input.botName, "none", 40).toLowerCase(),
+        };
+        await AnalyticsServerMetric_1.default.updateOne(dimensions, {
+            $setOnInsert: dimensions,
+            $set: { lastOccurredAt: occurredAt },
+            $inc: { count: 1, durationTotalMs: durationMs },
+            $max: { durationMaxMs: durationMs },
+        }, { upsert: true });
+    }
+    catch (error) {
+        // Analytics must never make a business request fail.
+        console.error("Server analytics metric failed:", error.message);
+    }
+};
+exports.recordServerMetric = recordServerMetric;

--- a/dist/services/emailSyncService.js
+++ b/dist/services/emailSyncService.js
@@ -8,6 +8,7 @@ const imapflow_1 = require("imapflow");
 const mailparser_1 = require("mailparser");
 const EmailMessage_1 = __importDefault(require("../models/EmailMessage"));
 const emailFilters_1 = require("../utils/emailFilters");
+const analyticsServerMetricService_1 = require("./analyticsServerMetricService");
 const normalizeEnvKey = (value) => value
     .trim()
     .replace(/[^a-z0-9_]/gi, "_")
@@ -181,6 +182,21 @@ const syncFolder = async (client, config, folder, limit, result) => {
             else {
                 await EmailMessage_1.default.create(payload);
                 result.imported += 1;
+                if (isSpam) {
+                    const folderClassified = String(folder.specialUse || "").toLowerCase() === "\\junk" ||
+                        /(^|[\/._ -])(spam|junk|promotions?)([\/._ -]|$)/i.test(folder.path);
+                    void (0, analyticsServerMetricService_1.recordServerMetric)({
+                        metricType: "spam_blocked",
+                        route: "mailbox_sync",
+                        method: "SYNC",
+                        outcome: "filtered",
+                        category: (0, emailFilters_1.isDmarcReport)(spamInput)
+                            ? "dmarc_report"
+                            : folderClassified
+                                ? "mailbox_folder"
+                                : "content_rule",
+                    });
+                }
             }
         }
         catch {

--- a/dist/services/searchConsoleService.js
+++ b/dist/services/searchConsoleService.js
@@ -1,0 +1,246 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getSearchConsoleReport = void 0;
+const crypto_1 = __importDefault(require("crypto"));
+const SearchConsoleCache_1 = __importDefault(require("../models/SearchConsoleCache"));
+const SEARCH_CONSOLE_SCOPE = "https://www.googleapis.com/auth/webmasters.readonly";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SEARCH_ANALYTICS_URL = "https://www.googleapis.com/webmasters/v3/sites";
+const DEFAULT_CACHE_MINUTES = 360;
+let accessTokenCache = null;
+const round = (value, precision = 2) => {
+    const factor = 10 ** precision;
+    return Math.round(value * factor) / factor;
+};
+const base64Url = (value) => Buffer.from(value)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+const getPrivateKey = () => {
+    const plain = String(process.env.GSC_SERVICE_ACCOUNT_PRIVATE_KEY || "").trim();
+    const encoded = String(process.env.GSC_SERVICE_ACCOUNT_PRIVATE_KEY_BASE64 || "").trim();
+    if (plain)
+        return plain.replace(/\\n/g, "\n");
+    if (!encoded)
+        return "";
+    try {
+        return Buffer.from(encoded, "base64").toString("utf8").replace(/\\n/g, "\n");
+    }
+    catch {
+        return "";
+    }
+};
+const getSiteUrls = () => Array.from(new Set(String(process.env.GSC_SITE_URLS || "")
+    .split(/[;,\n]/)
+    .map((value) => value.trim())
+    .filter(Boolean)));
+const getConfiguration = () => {
+    const clientEmail = String(process.env.GSC_SERVICE_ACCOUNT_EMAIL || "").trim();
+    const privateKey = getPrivateKey();
+    const siteUrls = getSiteUrls();
+    const missing = [];
+    if (!clientEmail)
+        missing.push("GSC_SERVICE_ACCOUNT_EMAIL");
+    if (!privateKey)
+        missing.push("GSC_SERVICE_ACCOUNT_PRIVATE_KEY_BASE64");
+    if (!siteUrls.length)
+        missing.push("GSC_SITE_URLS");
+    return { clientEmail, privateKey, siteUrls, missing };
+};
+const fetchWithTimeout = async (url, init, timeoutMs = 15000) => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await fetch(url, { ...init, signal: controller.signal });
+    }
+    finally {
+        clearTimeout(timeout);
+    }
+};
+const getAccessToken = async (clientEmail, privateKey) => {
+    if (accessTokenCache && accessTokenCache.expiresAt > Date.now() + 60000) {
+        return accessTokenCache.token;
+    }
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+    const claim = base64Url(JSON.stringify({
+        iss: clientEmail,
+        scope: SEARCH_CONSOLE_SCOPE,
+        aud: TOKEN_URL,
+        iat: issuedAt - 30,
+        exp: issuedAt + 3600,
+    }));
+    const unsignedToken = `${header}.${claim}`;
+    const signature = crypto_1.default.sign("RSA-SHA256", Buffer.from(unsignedToken), privateKey);
+    const assertion = `${unsignedToken}.${base64Url(signature)}`;
+    const response = await fetchWithTimeout(TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+            grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            assertion,
+        }),
+    });
+    const payload = await response.json();
+    if (!response.ok || !payload.access_token) {
+        throw new Error(payload.error_description || `Google OAuth failed (${response.status}).`);
+    }
+    accessTokenCache = {
+        token: payload.access_token,
+        expiresAt: Date.now() + Math.max(300, Number(payload.expires_in || 3600)) * 1000,
+    };
+    return payload.access_token;
+};
+const querySearchAnalytics = async (accessToken, siteUrl, startDate, endDate, dimensions, rowLimit) => {
+    var _a;
+    const response = await fetchWithTimeout(`${SEARCH_ANALYTICS_URL}/${encodeURIComponent(siteUrl)}/searchAnalytics/query`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            startDate,
+            endDate,
+            dimensions,
+            type: "web",
+            aggregationType: dimensions.includes("page") ? "auto" : "byProperty",
+            dataState: "final",
+            rowLimit,
+            startRow: 0,
+        }),
+    });
+    const payload = await response.json();
+    if (!response.ok) {
+        throw new Error(((_a = payload.error) === null || _a === void 0 ? void 0 : _a.message) || `Search Console query failed (${response.status}).`);
+    }
+    return payload.rows || [];
+};
+const normalizeRow = (row, name) => ({
+    name,
+    clicks: Math.round(Number(row.clicks || 0)),
+    impressions: Math.round(Number(row.impressions || 0)),
+    ctr: round(Number(row.ctr || 0) * 100),
+    position: round(Number(row.position || 0)),
+});
+const queryProperty = async (accessToken, siteUrl, startDate, endDate) => {
+    const [summaryRows, timelineRows, queryRows, pageRows, countryRows, deviceRows] = await Promise.all([
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, [], 1),
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["date"], 500),
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["query"], 100),
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["page"], 100),
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["country"], 50),
+        querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["device"], 10),
+    ]);
+    return {
+        siteUrl,
+        summary: normalizeRow(summaryRows[0] || {}, siteUrl),
+        timeline: timelineRows.map((row) => { var _a; return normalizeRow(row, ((_a = row.keys) === null || _a === void 0 ? void 0 : _a[0]) || "unknown"); }),
+        queries: queryRows.map((row) => { var _a; return normalizeRow(row, ((_a = row.keys) === null || _a === void 0 ? void 0 : _a[0]) || "Unknown query"); }),
+        pages: pageRows.map((row) => { var _a; return normalizeRow(row, ((_a = row.keys) === null || _a === void 0 ? void 0 : _a[0]) || "/"); }),
+        countries: countryRows.map((row) => { var _a; return normalizeRow(row, ((_a = row.keys) === null || _a === void 0 ? void 0 : _a[0]) || "unknown"); }),
+        devices: deviceRows.map((row) => { var _a; return normalizeRow(row, ((_a = row.keys) === null || _a === void 0 ? void 0 : _a[0]) || "unknown"); }),
+    };
+};
+const mergeRows = (rows, sortBy = "clicks") => {
+    const merged = new Map();
+    rows.forEach((row) => {
+        const current = merged.get(row.name) || { name: row.name, clicks: 0, impressions: 0, positionWeight: 0 };
+        current.clicks += row.clicks;
+        current.impressions += row.impressions;
+        current.positionWeight += row.position * row.impressions;
+        merged.set(row.name, current);
+    });
+    const result = Array.from(merged.values()).map((row) => ({
+        name: row.name,
+        clicks: row.clicks,
+        impressions: row.impressions,
+        ctr: row.impressions > 0 ? round((row.clicks / row.impressions) * 100) : 0,
+        position: row.impressions > 0 ? round(row.positionWeight / row.impressions) : 0,
+    }));
+    return result.sort((left, right) => sortBy === "name" ? left.name.localeCompare(right.name) : right.clicks - left.clicks || right.impressions - left.impressions);
+};
+const buildMergedReport = (properties, startDate, endDate) => {
+    const propertySummaries = properties.map((property) => property.summary);
+    const totalClicks = propertySummaries.reduce((sum, row) => sum + row.clicks, 0);
+    const totalImpressions = propertySummaries.reduce((sum, row) => sum + row.impressions, 0);
+    const positionWeight = propertySummaries.reduce((sum, row) => sum + row.position * row.impressions, 0);
+    const timeline = mergeRows(properties.flatMap((property) => property.timeline), "name");
+    return {
+        configured: true,
+        status: "connected",
+        startDate,
+        endDate,
+        dataThrough: timeline.length ? timeline[timeline.length - 1].name : null,
+        summary: {
+            clicks: totalClicks,
+            impressions: totalImpressions,
+            ctr: totalImpressions > 0 ? round((totalClicks / totalImpressions) * 100) : 0,
+            position: totalImpressions > 0 ? round(positionWeight / totalImpressions) : 0,
+        },
+        timeline,
+        queries: mergeRows(properties.flatMap((property) => property.queries)).slice(0, 100),
+        pages: mergeRows(properties.flatMap((property) => property.pages)).slice(0, 100),
+        countries: mergeRows(properties.flatMap((property) => property.countries)).slice(0, 50),
+        devices: mergeRows(properties.flatMap((property) => property.devices)).slice(0, 10),
+        properties: properties.map((property) => ({ siteUrl: property.siteUrl, ...property.summary })),
+    };
+};
+const toDateOnly = (value) => value.toISOString().slice(0, 10);
+const getSearchConsoleReport = async (from, to) => {
+    const configuration = getConfiguration();
+    if (configuration.missing.length) {
+        return {
+            configured: false,
+            status: "not_configured",
+            missing: configuration.missing,
+            message: "Google Search Console is ready but its server credentials are not configured yet.",
+        };
+    }
+    const startDate = toDateOnly(from);
+    const endDate = toDateOnly(to);
+    const cacheKey = crypto_1.default
+        .createHash("sha256")
+        .update(`${[...configuration.siteUrls].sort().join("|")}:${startDate}:${endDate}:web:v1`)
+        .digest("hex");
+    const cached = await SearchConsoleCache_1.default.findOne({ cacheKey }).lean();
+    if (cached && cached.expiresAt.getTime() > Date.now()) {
+        return { ...cached.payload, cached: true, fetchedAt: cached.fetchedAt };
+    }
+    try {
+        const accessToken = await getAccessToken(configuration.clientEmail, configuration.privateKey);
+        const properties = await Promise.all(configuration.siteUrls.map((siteUrl) => queryProperty(accessToken, siteUrl, startDate, endDate)));
+        const report = buildMergedReport(properties, startDate, endDate);
+        const fetchedAt = new Date();
+        const configuredMinutes = Number(process.env.GSC_CACHE_MINUTES || DEFAULT_CACHE_MINUTES);
+        const cacheMinutes = Number.isFinite(configuredMinutes)
+            ? Math.max(15, Math.min(1440, configuredMinutes))
+            : DEFAULT_CACHE_MINUTES;
+        const expiresAt = new Date(fetchedAt.getTime() + cacheMinutes * 60000);
+        const deleteAfter = new Date(fetchedAt.getTime() + 7 * 24 * 60 * 60000);
+        await SearchConsoleCache_1.default.updateOne({ cacheKey }, { $set: { payload: report, fetchedAt, expiresAt, deleteAfter } }, { upsert: true });
+        return { ...report, cached: false, fetchedAt };
+    }
+    catch (error) {
+        if (cached) {
+            return {
+                ...cached.payload,
+                cached: true,
+                stale: true,
+                fetchedAt: cached.fetchedAt,
+                warning: error.message.slice(0, 240),
+            };
+        }
+        return {
+            configured: true,
+            status: "error",
+            message: error.message.slice(0, 240),
+            properties: configuration.siteUrls.map((siteUrl) => ({ siteUrl })),
+        };
+    }
+};
+exports.getSearchConsoleReport = getSearchConsoleReport;

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import express from "express";
 import dotenv from "dotenv";
 import cors from "cors";
 import routes from "./routes";
+import errorHandler from "./middleware/errorHandler";
+import { analyticsServerMiddleware } from "./middleware/analyticsServerMiddleware";
 
 dotenv.config();
 
@@ -17,6 +19,7 @@ app.use(
   })
 );
 
+app.use(analyticsServerMiddleware);
 app.use(express.json());
 
 app.get("/", (req, res) => {
@@ -25,5 +28,11 @@ app.get("/", (req, res) => {
 });
 
 app.use("/api", routes);
+
+app.use((_req, res) => {
+  res.status(404).json({ message: "Route not found." });
+});
+
+app.use(errorHandler);
 
 export default app;

--- a/src/controllers/analyticsIncidentController.ts
+++ b/src/controllers/analyticsIncidentController.ts
@@ -1,0 +1,93 @@
+import { NextFunction, Request, Response } from "express";
+import AnalyticsIncident, {
+  AnalyticsIncidentStatus,
+} from "../models/AnalyticsIncident";
+import {
+  evaluateAnalyticsAnomalies,
+  getAnalyticsIncidentSummary,
+} from "../services/analyticsAnomalyService";
+
+const allowedStatuses: AnalyticsIncidentStatus[] = ["open", "acknowledged", "resolved"];
+
+export const listAnalyticsIncidents = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const requestedStatus = String(req.query.status || "active");
+    const filter = requestedStatus === "all"
+      ? {}
+      : requestedStatus === "resolved"
+        ? { status: "resolved" }
+        : { status: { $in: ["open", "acknowledged"] } };
+    const incidents = await AnalyticsIncident.find(filter).sort({ lastDetectedAt: -1 }).limit(100).lean();
+    res.status(200).json({ incidents });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAnalyticsIncidentSummaryController = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    res.status(200).json({ metrics: await getAnalyticsIncidentSummary() });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const evaluateAnalyticsIncidentsController = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const incidents = await evaluateAnalyticsAnomalies(true);
+    res.status(200).json({ incidents, metrics: await getAnalyticsIncidentSummary() });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateAnalyticsIncidentStatus = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const status = String(req.body?.status || "") as AnalyticsIncidentStatus;
+    if (!allowedStatuses.includes(status)) {
+      res.status(400).json({ message: "Invalid incident status." });
+      return;
+    }
+    const incident = await AnalyticsIncident.findById(req.params.id);
+    if (!incident) {
+      res.status(404).json({ message: "Analytics incident not found." });
+      return;
+    }
+    const actorEmail = String(req.user?.email || "").toLowerCase();
+    incident.status = status;
+    if (status === "acknowledged") {
+      incident.acknowledgedAt = new Date();
+      incident.acknowledgedByEmail = actorEmail;
+    }
+    if (status === "resolved") {
+      incident.resolvedAt = new Date();
+      incident.resolvedByEmail = actorEmail;
+    }
+    if (status === "open") {
+      incident.acknowledgedAt = undefined;
+      incident.acknowledgedByEmail = undefined;
+      incident.resolvedAt = undefined;
+      incident.resolvedByEmail = undefined;
+    }
+    await incident.save();
+    res.status(200).json({ incident });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/analyticsReportController.ts
+++ b/src/controllers/analyticsReportController.ts
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from "express";
+import {
+  buildAnalyticsOverview,
+  getRealtimeAnalytics,
+  resolveAnalyticsDateRange,
+} from "../services/analyticsReportService";
+
+export const getAnalyticsOverview = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const range = resolveAnalyticsDateRange(req.query as Record<string, unknown>);
+    const report = await buildAnalyticsOverview(range);
+    res.status(200).json(report);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAnalyticsRealtime = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    res.status(200).json(await getRealtimeAnalytics());
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/controllers/healthController.ts
+++ b/src/controllers/healthController.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { NextFunction, Request, Response } from "express";
+import mongoose from "mongoose";
+import AnalyticsServerMetric from "../models/AnalyticsServerMetric";
+import {
+  evaluateAnalyticsAnomalies,
+  getAnalyticsIncidentSummary,
+} from "../services/analyticsAnomalyService";
+
+const commit = () => process.env.VERCEL_GIT_COMMIT_SHA || "local";
+
+export const getLiveness = (_req: Request, res: Response): void => {
+  res.status(200).json({
+    status: "ok",
+    service: "creativa-poeta-backend",
+    timestamp: new Date().toISOString(),
+    commit: commit(),
+  });
+};
+
+export const getReadiness = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    let database = mongoose.connection.readyState === 1 ? "connected" : "disconnected";
+    if (database === "connected") {
+      try {
+        await mongoose.connection.db?.admin().ping();
+      } catch {
+        database = "unavailable";
+      }
+    }
+
+    const ready = database === "connected";
+    const latestMetric = ready
+      ? await AnalyticsServerMetric.findOne().sort({ lastOccurredAt: -1 }).select("lastOccurredAt").lean()
+      : null;
+    res.status(ready ? 200 : 503).json({
+      status: ready ? "ready" : "degraded",
+      service: "creativa-poeta-backend",
+      database,
+      timestamp: new Date().toISOString(),
+      commit: commit(),
+      latestServerMetricAt: latestMetric?.lastOccurredAt || null,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const safeEqual = (left: string, right: string) => {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && crypto.timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+export const runMonitoringEvaluation = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const configuredSecret = String(
+      process.env.ANALYTICS_MONITOR_SECRET || process.env.CRON_SECRET || ""
+    ).trim();
+    const bearer = String(req.get("authorization") || "").replace(/^Bearer\s+/i, "").trim();
+    const providedSecret = String(req.get("x-cp-monitor-secret") || bearer).trim();
+
+    if (!configuredSecret) {
+      res.status(503).json({ status: "not_configured" });
+      return;
+    }
+    if (!providedSecret || !safeEqual(providedSecret, configuredSecret)) {
+      res.status(401).json({ status: "unauthorized" });
+      return;
+    }
+
+    const incidents = await evaluateAnalyticsAnomalies(true);
+    const summary = await getAnalyticsIncidentSummary();
+    res.status(summary.critical > 0 ? 503 : 200).json({
+      status: summary.critical > 0 ? "critical" : summary.warning > 0 ? "warning" : "healthy",
+      evaluatedAt: new Date().toISOString(),
+      summary,
+      incidents: incidents.map((incident) => ({
+        type: incident.type,
+        severity: incident.severity,
+        status: incident.status,
+        lastDetectedAt: incident.lastDetectedAt,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/middleware/analyticsServerMiddleware.ts
+++ b/src/middleware/analyticsServerMiddleware.ts
@@ -1,0 +1,107 @@
+import { NextFunction, Request, Response } from "express";
+import { recordServerMetric } from "../services/analyticsServerMetricService";
+
+const botPattern =
+  /(googlebot|bingbot|yandexbot|baiduspider|duckduckbot|facebookexternalhit|linkedinbot|twitterbot|slurp|semrushbot|ahrefsbot|mj12bot|crawler|spider|bot)/i;
+
+const normalizeRoute = (originalUrl: string) => {
+  const path = String(originalUrl || "/").split(/[?#]/)[0] || "/";
+  return path
+    .split("/")
+    .map((segment) => {
+      if (/^[a-f0-9]{24}$/i.test(segment)) return ":id";
+      if (/^[0-9]+$/.test(segment)) return ":id";
+      if (/^[a-f0-9-]{32,36}$/i.test(segment)) return ":id";
+      if (/^[A-Za-z0-9_-]{40,}$/.test(segment)) return ":token";
+      return segment.slice(0, 60);
+    })
+    .join("/")
+    .slice(0, 180);
+};
+
+const getBot = (req: Request) => {
+  const match = String(req.get("user-agent") || "").match(botPattern)?.[1];
+  return { isBot: Boolean(match), botName: match?.toLowerCase() || "none" };
+};
+
+const getCountry = (req: Request) =>
+  String(req.get("x-vercel-ip-country") || "unknown").trim().slice(0, 4).toUpperCase();
+
+const formRoutes: Record<string, string> = {
+  "/api/contact/send": "contact",
+  "/api/project/send-inquiry": "project",
+  "/api/partnership-requests": "partnership",
+  "/api/job/apply": "job_application",
+  "/api/visibility-audit/technical": "visibility_audit",
+  "/api/visibility-audit/interpret": "visibility_audit",
+};
+
+export const analyticsServerMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (String(req.originalUrl || "").split(/[?#]/)[0] === "/api/health/live") {
+    next();
+    return;
+  }
+
+  const startedAt = process.hrtime.bigint();
+
+  res.once("finish", () => {
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    const route = normalizeRoute(req.originalUrl);
+    const bot = getBot(req);
+    const country = getCountry(req);
+    const outcome = res.statusCode >= 500
+      ? "server_error"
+      : res.statusCode === 404
+        ? "not_found"
+        : res.statusCode >= 400
+          ? "rejected"
+          : "success";
+
+    void recordServerMetric({
+      metricType: "api_request",
+      route,
+      method: req.method,
+      statusCode: res.statusCode,
+      outcome,
+      category: route.startsWith("/api/") ? "api" : "service",
+      country,
+      ...bot,
+      durationMs,
+    });
+
+    if (route === "/api/auth/login" && req.method === "POST") {
+      void recordServerMetric({
+        metricType: "auth_attempt",
+        route,
+        method: req.method,
+        statusCode: res.statusCode,
+        outcome: res.statusCode >= 200 && res.statusCode < 300 ? "success" : "denied",
+        category: "admin_login",
+        country,
+        ...bot,
+        durationMs,
+      });
+    }
+
+    const formType = req.method === "POST" ? formRoutes[route] : undefined;
+    if (formType) {
+      void recordServerMetric({
+        metricType: "form_submission",
+        route,
+        method: req.method,
+        statusCode: res.statusCode,
+        outcome: res.statusCode >= 200 && res.statusCode < 300 ? "success" : "failed",
+        category: formType,
+        country,
+        ...bot,
+        durationMs,
+      });
+    }
+  });
+
+  next();
+};

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -98,9 +98,7 @@ export const authenticateUser = (
     req.user = { ...decoded, role: getEffectiveAdminRole(decoded.role, decoded.email) };
     next();
   } catch (err: any) {
-    console.error("Token verification error:", err.message);
-    console.error("Token:", token.substring(0, 50) + "...");
-    console.error("JWT_SECRET length:", JWT_SECRET ? JWT_SECRET.length : 0);
+    console.warn("Admin token verification failed:", err?.name || "unknown_error");
 
     if (err.name === "JsonWebTokenError") {
       res

--- a/src/models/AnalyticsIncident.ts
+++ b/src/models/AnalyticsIncident.ts
@@ -1,0 +1,68 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export type AnalyticsIncidentSeverity = "info" | "warning" | "critical";
+export type AnalyticsIncidentStatus = "open" | "acknowledged" | "resolved";
+
+export interface IAnalyticsIncident extends Document {
+  fingerprint: string;
+  type: string;
+  source: string;
+  severity: AnalyticsIncidentSeverity;
+  status: AnalyticsIncidentStatus;
+  title: string;
+  message: string;
+  metric: string;
+  currentValue: number;
+  baselineValue: number;
+  changePercent: number;
+  threshold: number;
+  occurrences: number;
+  firstDetectedAt: Date;
+  lastDetectedAt: Date;
+  acknowledgedAt?: Date;
+  acknowledgedByEmail?: string;
+  resolvedAt?: Date;
+  resolvedByEmail?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AnalyticsIncidentSchema = new Schema<IAnalyticsIncident>(
+  {
+    fingerprint: { type: String, required: true, unique: true, trim: true, maxlength: 120 },
+    type: { type: String, required: true, trim: true, maxlength: 80, index: true },
+    source: { type: String, required: true, trim: true, maxlength: 40, default: "server" },
+    severity: {
+      type: String,
+      required: true,
+      enum: ["info", "warning", "critical"],
+      index: true,
+    },
+    status: {
+      type: String,
+      required: true,
+      enum: ["open", "acknowledged", "resolved"],
+      default: "open",
+      index: true,
+    },
+    title: { type: String, required: true, trim: true, maxlength: 180 },
+    message: { type: String, required: true, trim: true, maxlength: 600 },
+    metric: { type: String, required: true, trim: true, maxlength: 80 },
+    currentValue: { type: Number, required: true, default: 0 },
+    baselineValue: { type: Number, required: true, default: 0 },
+    changePercent: { type: Number, required: true, default: 0 },
+    threshold: { type: Number, required: true, default: 0 },
+    occurrences: { type: Number, required: true, min: 1, default: 1 },
+    firstDetectedAt: { type: Date, required: true, default: Date.now },
+    lastDetectedAt: { type: Date, required: true, default: Date.now },
+    acknowledgedAt: { type: Date },
+    acknowledgedByEmail: { type: String, trim: true, lowercase: true, maxlength: 320 },
+    resolvedAt: { type: Date },
+    resolvedByEmail: { type: String, trim: true, lowercase: true, maxlength: 320 },
+  },
+  { timestamps: true, versionKey: false }
+);
+
+AnalyticsIncidentSchema.index({ status: 1, severity: 1, lastDetectedAt: -1 });
+
+export default mongoose.model<IAnalyticsIncident>("AnalyticsIncident", AnalyticsIncidentSchema);

--- a/src/models/AnalyticsServerMetric.ts
+++ b/src/models/AnalyticsServerMetric.ts
@@ -1,0 +1,79 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export type AnalyticsServerMetricType =
+  | "api_request"
+  | "auth_attempt"
+  | "form_submission"
+  | "spam_blocked";
+
+export interface IAnalyticsServerMetric extends Document {
+  bucketStart: Date;
+  metricType: AnalyticsServerMetricType;
+  route: string;
+  method: string;
+  statusCode: number;
+  outcome: string;
+  category: string;
+  country: string;
+  isBot: boolean;
+  botName: string;
+  count: number;
+  durationTotalMs: number;
+  durationMaxMs: number;
+  lastOccurredAt: Date;
+}
+
+const configuredRetentionDays = Number(process.env.ANALYTICS_RETENTION_DAYS || 395);
+const retentionDays = Number.isFinite(configuredRetentionDays)
+  ? Math.max(30, configuredRetentionDays)
+  : 395;
+
+const AnalyticsServerMetricSchema = new Schema<IAnalyticsServerMetric>(
+  {
+    bucketStart: { type: Date, required: true },
+    metricType: {
+      type: String,
+      required: true,
+      enum: ["api_request", "auth_attempt", "form_submission", "spam_blocked"],
+    },
+    route: { type: String, required: true, trim: true, maxlength: 180, default: "unknown" },
+    method: { type: String, required: true, trim: true, maxlength: 12, default: "UNKNOWN" },
+    statusCode: { type: Number, required: true, min: 0, max: 999, default: 0 },
+    outcome: { type: String, required: true, trim: true, maxlength: 40, default: "unknown" },
+    category: { type: String, required: true, trim: true, maxlength: 80, default: "general" },
+    country: { type: String, required: true, trim: true, maxlength: 4, default: "unknown" },
+    isBot: { type: Boolean, required: true, default: false },
+    botName: { type: String, required: true, trim: true, maxlength: 40, default: "none" },
+    count: { type: Number, required: true, min: 0, default: 0 },
+    durationTotalMs: { type: Number, required: true, min: 0, default: 0 },
+    durationMaxMs: { type: Number, required: true, min: 0, default: 0 },
+    lastOccurredAt: { type: Date, required: true, default: Date.now },
+  },
+  { versionKey: false }
+);
+
+AnalyticsServerMetricSchema.index(
+  {
+    bucketStart: 1,
+    metricType: 1,
+    route: 1,
+    method: 1,
+    statusCode: 1,
+    outcome: 1,
+    category: 1,
+    country: 1,
+    isBot: 1,
+    botName: 1,
+  },
+  { unique: true, name: "analytics_server_metric_bucket" }
+);
+AnalyticsServerMetricSchema.index({ metricType: 1, bucketStart: -1 });
+AnalyticsServerMetricSchema.index(
+  { bucketStart: 1 },
+  { expireAfterSeconds: retentionDays * 24 * 60 * 60 }
+);
+
+export default mongoose.model<IAnalyticsServerMetric>(
+  "AnalyticsServerMetric",
+  AnalyticsServerMetricSchema
+);

--- a/src/models/AnalyticsSession.ts
+++ b/src/models/AnalyticsSession.ts
@@ -65,7 +65,9 @@ const AnalyticsSessionSchema = new Schema<IAnalyticsSession>(
 
 AnalyticsSessionSchema.index({ sessionId: 1 }, { unique: true });
 AnalyticsSessionSchema.index({ visitorId: 1, startedAt: -1 });
+AnalyticsSessionSchema.index({ startedAt: -1, isBot: 1 });
 AnalyticsSessionSchema.index({ lastSeenAt: -1 });
+AnalyticsSessionSchema.index({ lastSeenAt: -1, isBot: 1 });
 AnalyticsSessionSchema.index({ lastSeenAt: 1 }, { expireAfterSeconds: retentionSeconds });
 
 export default mongoose.model<IAnalyticsSession>("AnalyticsSession", AnalyticsSessionSchema);

--- a/src/models/SearchConsoleCache.ts
+++ b/src/models/SearchConsoleCache.ts
@@ -1,0 +1,28 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface ISearchConsoleCache extends Document {
+  cacheKey: string;
+  payload: Record<string, unknown>;
+  fetchedAt: Date;
+  expiresAt: Date;
+  deleteAfter: Date;
+}
+
+const SearchConsoleCacheSchema = new Schema<ISearchConsoleCache>(
+  {
+    cacheKey: { type: String, required: true, unique: true, maxlength: 128 },
+    payload: { type: Schema.Types.Mixed, required: true },
+    fetchedAt: { type: Date, required: true },
+    expiresAt: { type: Date, required: true },
+    deleteAfter: { type: Date, required: true },
+  },
+  { versionKey: false }
+);
+
+SearchConsoleCacheSchema.index({ expiresAt: 1 });
+SearchConsoleCacheSchema.index({ deleteAfter: 1 }, { expireAfterSeconds: 0 });
+
+export default mongoose.model<ISearchConsoleCache>(
+  "SearchConsoleCache",
+  SearchConsoleCacheSchema
+);

--- a/src/routes/analyticsRoutes.ts
+++ b/src/routes/analyticsRoutes.ts
@@ -5,6 +5,16 @@ import {
 } from "../controllers/analyticsController";
 import { authenticateUser } from "../middleware/authMiddleware";
 import { authorizeAdminPermission } from "../middleware/permissionMiddleware";
+import {
+  getAnalyticsOverview,
+  getAnalyticsRealtime,
+} from "../controllers/analyticsReportController";
+import {
+  evaluateAnalyticsIncidentsController,
+  getAnalyticsIncidentSummaryController,
+  listAnalyticsIncidents,
+  updateAnalyticsIncidentStatus,
+} from "../controllers/analyticsIncidentController";
 
 const router = express.Router();
 const canReadAnalytics = authorizeAdminPermission("analytics:read", [
@@ -15,5 +25,11 @@ const canReadAnalytics = authorizeAdminPermission("analytics:read", [
 
 router.post("/collect", collectAnalyticsEvents);
 router.get("/health", authenticateUser, canReadAnalytics, getAnalyticsCollectionHealth);
+router.get("/overview", authenticateUser, canReadAnalytics, getAnalyticsOverview);
+router.get("/realtime", authenticateUser, canReadAnalytics, getAnalyticsRealtime);
+router.get("/incidents", authenticateUser, canReadAnalytics, listAnalyticsIncidents);
+router.get("/incidents/summary", authenticateUser, canReadAnalytics, getAnalyticsIncidentSummaryController);
+router.post("/incidents/evaluate", authenticateUser, canReadAnalytics, evaluateAnalyticsIncidentsController);
+router.patch("/incidents/:id/status", authenticateUser, canReadAnalytics, updateAnalyticsIncidentStatus);
 
 export default router;

--- a/src/routes/healthRoutes.ts
+++ b/src/routes/healthRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import {
+  getLiveness,
+  getReadiness,
+  runMonitoringEvaluation,
+} from "../controllers/healthController";
+
+const router = Router();
+
+router.get("/live", getLiveness);
+router.get("/ready", getReadiness);
+router.get("/monitor", runMonitoringEvaluation);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ import adminNotificationRouter from "./adminNotificationRoutes";
 import internalMessageRouter from "./internalMessageRoutes";
 import partnershipRequestRouter from "./partnershipRequestRoutes";
 import analyticsRouter from "./analyticsRoutes";
+import healthRouter from "./healthRoutes";
 
 const router = express.Router();
 
@@ -27,6 +28,7 @@ router.use("/jobs", CareerRouter);
 router.use("/visibility-audit", visibilityAuditRouter);
 router.use("/partnership-requests", partnershipRequestRouter);
 router.use("/analytics", analyticsRouter);
+router.use("/health", healthRouter);
 
 // Email test endpoint for debugging
 router.get("/test-email", testEmail);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,14 +3,14 @@ import app from "./app";
 
 const MONGO_URI = process.env.MONGO_URI || "";
 
-if (!MONGO_URI) {
-  throw new Error("MONGO_URI environment variable is required");
-}
-
 let isConnected = false;
 
 async function connectDB() {
   if (isConnected) return;
+  if (!MONGO_URI) {
+    console.error("MONGO_URI environment variable is required for database-backed endpoints");
+    return;
+  }
 
   try {
     const db = await mongoose.connect(MONGO_URI, {
@@ -24,6 +24,9 @@ async function connectDB() {
 }
 
 export default async function handler(req: any, res: any) {
-  await connectDB();
+  const requestPath = String(req.url || "").split("?")[0];
+  if (requestPath !== "/api/health/live") {
+    await connectDB();
+  }
   return app(req, res);
 }

--- a/src/services/analyticsAnomalyService.ts
+++ b/src/services/analyticsAnomalyService.ts
@@ -1,0 +1,385 @@
+import AnalyticsEvent from "../models/AnalyticsEvent";
+import AnalyticsIncident, {
+  AnalyticsIncidentSeverity,
+} from "../models/AnalyticsIncident";
+import AnalyticsServerMetric from "../models/AnalyticsServerMetric";
+
+interface OperationalWindow {
+  requests: number;
+  serverErrors: number;
+  durationTotalMs: number;
+  authDenied: number;
+  formAttempts: number;
+  formFailures: number;
+  spamBlocked: number;
+  botRequests: number;
+}
+
+interface DetectedIncident {
+  fingerprint: string;
+  type: string;
+  source: string;
+  severity: AnalyticsIncidentSeverity;
+  title: string;
+  message: string;
+  metric: string;
+  currentValue: number;
+  baselineValue: number;
+  changePercent: number;
+  threshold: number;
+}
+
+let lastEvaluationAt = 0;
+let evaluationPromise: Promise<ReturnType<typeof serializeIncident>[]> | null = null;
+
+const round = (value: number, precision = 1) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const percentChange = (current: number, baseline: number) => {
+  if (baseline <= 0) return current > 0 ? 100 : 0;
+  return round(((current - baseline) / baseline) * 100);
+};
+
+const serializeIncident = (incident: any) => ({
+  id: String(incident._id),
+  type: incident.type,
+  source: incident.source,
+  severity: incident.severity,
+  status: incident.status,
+  title: incident.title,
+  message: incident.message,
+  metric: incident.metric,
+  currentValue: incident.currentValue,
+  baselineValue: incident.baselineValue,
+  changePercent: incident.changePercent,
+  threshold: incident.threshold,
+  occurrences: incident.occurrences,
+  firstDetectedAt: incident.firstDetectedAt,
+  lastDetectedAt: incident.lastDetectedAt,
+  acknowledgedAt: incident.acknowledgedAt,
+  resolvedAt: incident.resolvedAt,
+});
+
+const aggregateWindow = async (from: Date, to: Date): Promise<OperationalWindow> => {
+  const rows = await AnalyticsServerMetric.aggregate([
+    { $match: { bucketStart: { $gte: from, $lt: to } } },
+    {
+      $group: {
+        _id: null,
+        requests: { $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$count", 0] } },
+        serverErrors: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        durationTotalMs: {
+          $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$durationTotalMs", 0] },
+        },
+        authDenied: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        formAttempts: {
+          $sum: { $cond: [{ $eq: ["$metricType", "form_submission"] }, "$count", 0] },
+        },
+        formFailures: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        spamBlocked: { $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] } },
+        botRequests: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  const row = rows[0] || {};
+  return {
+    requests: Number(row.requests || 0),
+    serverErrors: Number(row.serverErrors || 0),
+    durationTotalMs: Number(row.durationTotalMs || 0),
+    authDenied: Number(row.authDenied || 0),
+    formAttempts: Number(row.formAttempts || 0),
+    formFailures: Number(row.formFailures || 0),
+    spamBlocked: Number(row.spamBlocked || 0),
+    botRequests: Number(row.botRequests || 0),
+  };
+};
+
+const detectOperationalIncidents = (
+  current: OperationalWindow,
+  baselineSevenDays: OperationalWindow
+) => {
+  const detected: DetectedIncident[] = [];
+  const dailyBaseline = Object.fromEntries(
+    Object.entries(baselineSevenDays).map(([key, value]) => [key, Number(value || 0) / 7])
+  ) as unknown as OperationalWindow;
+  const availability = current.requests > 0
+    ? ((current.requests - current.serverErrors) / current.requests) * 100
+    : 100;
+  const averageLatency = current.requests > 0 ? current.durationTotalMs / current.requests : 0;
+  const baselineLatency = dailyBaseline.requests > 0
+    ? dailyBaseline.durationTotalMs / dailyBaseline.requests
+    : 0;
+  const formFailureRate = current.formAttempts > 0
+    ? (current.formFailures / current.formAttempts) * 100
+    : 0;
+
+  if (current.requests >= 10 && availability < 99.5) {
+    detected.push({
+      fingerprint: "server:availability",
+      type: "availability_drop",
+      source: "server",
+      severity: availability < 98 ? "critical" : "warning",
+      title: "Observed API availability has dropped",
+      message: `${current.serverErrors} server error(s) were observed across ${current.requests} API requests in the last 24 hours.`,
+      metric: "observedAvailability",
+      currentValue: round(availability, 2),
+      baselineValue: 100,
+      changePercent: round(availability - 100, 2),
+      threshold: 99.5,
+    });
+  }
+
+  if (
+    current.requests >= 10 &&
+    averageLatency > 1_000 &&
+    (baselineLatency === 0 || averageLatency > baselineLatency * 1.8)
+  ) {
+    detected.push({
+      fingerprint: "server:latency",
+      type: "latency_spike",
+      source: "server",
+      severity: averageLatency > 2_500 ? "critical" : "warning",
+      title: "API response time is unusually high",
+      message: `Average API response time reached ${Math.round(averageLatency)} ms during the last 24 hours.`,
+      metric: "averageResponseMs",
+      currentValue: round(averageLatency),
+      baselineValue: round(baselineLatency),
+      changePercent: percentChange(averageLatency, baselineLatency),
+      threshold: 1_000,
+    });
+  }
+
+  if (
+    current.serverErrors >= 3 &&
+    (dailyBaseline.serverErrors === 0 || current.serverErrors > dailyBaseline.serverErrors * 2)
+  ) {
+    detected.push({
+      fingerprint: "server:errors",
+      type: "server_error_spike",
+      source: "server",
+      severity: current.serverErrors >= 10 ? "critical" : "warning",
+      title: "Server errors are increasing",
+      message: `${current.serverErrors} HTTP 5xx responses were recorded in the last 24 hours.`,
+      metric: "serverErrors",
+      currentValue: current.serverErrors,
+      baselineValue: round(dailyBaseline.serverErrors),
+      changePercent: percentChange(current.serverErrors, dailyBaseline.serverErrors),
+      threshold: 3,
+    });
+  }
+
+  if (
+    current.authDenied >= 5 &&
+    (dailyBaseline.authDenied === 0 || current.authDenied > dailyBaseline.authDenied * 2)
+  ) {
+    detected.push({
+      fingerprint: "security:auth-denied",
+      type: "auth_failure_spike",
+      source: "security",
+      severity: current.authDenied >= 20 ? "critical" : "warning",
+      title: "Unusual number of denied admin logins",
+      message: `${current.authDenied} admin login attempts were denied in the last 24 hours.`,
+      metric: "authDenied",
+      currentValue: current.authDenied,
+      baselineValue: round(dailyBaseline.authDenied),
+      changePercent: percentChange(current.authDenied, dailyBaseline.authDenied),
+      threshold: 5,
+    });
+  }
+
+  if (current.formAttempts >= 5 && current.formFailures >= 3 && formFailureRate >= 20) {
+    detected.push({
+      fingerprint: "forms:failures",
+      type: "form_failure_spike",
+      source: "forms",
+      severity: formFailureRate >= 50 || current.formFailures >= 10 ? "critical" : "warning",
+      title: "Public forms are failing unusually often",
+      message: `${current.formFailures} of ${current.formAttempts} server-side form submissions failed in the last 24 hours.`,
+      metric: "formFailureRate",
+      currentValue: round(formFailureRate),
+      baselineValue: dailyBaseline.formAttempts > 0
+        ? round((dailyBaseline.formFailures / dailyBaseline.formAttempts) * 100)
+        : 0,
+      changePercent: percentChange(current.formFailures, dailyBaseline.formFailures),
+      threshold: 20,
+    });
+  }
+
+  if (
+    current.spamBlocked >= 10 &&
+    (dailyBaseline.spamBlocked === 0 || current.spamBlocked > dailyBaseline.spamBlocked * 3)
+  ) {
+    detected.push({
+      fingerprint: "mail:spam",
+      type: "spam_spike",
+      source: "mail",
+      severity: current.spamBlocked >= 50 ? "warning" : "info",
+      title: "Spam volume is above its usual level",
+      message: `${current.spamBlocked} new messages were filtered as spam during the last 24 hours.`,
+      metric: "spamBlocked",
+      currentValue: current.spamBlocked,
+      baselineValue: round(dailyBaseline.spamBlocked),
+      changePercent: percentChange(current.spamBlocked, dailyBaseline.spamBlocked),
+      threshold: 10,
+    });
+  }
+
+  if (
+    current.botRequests >= 25 &&
+    (dailyBaseline.botRequests === 0 || current.botRequests > dailyBaseline.botRequests * 3)
+  ) {
+    detected.push({
+      fingerprint: "security:bots",
+      type: "bot_traffic_spike",
+      source: "security",
+      severity: current.botRequests >= 200 ? "warning" : "info",
+      title: "Automated traffic is above its usual level",
+      message: `${current.botRequests} bot requests were identified during the last 24 hours.`,
+      metric: "botRequests",
+      currentValue: current.botRequests,
+      baselineValue: round(dailyBaseline.botRequests),
+      changePercent: percentChange(current.botRequests, dailyBaseline.botRequests),
+      threshold: 25,
+    });
+  }
+
+  return detected;
+};
+
+const upsertDetectedIncidents = async (detected: DetectedIncident[], now: Date) => {
+  const fingerprints = detected.map((incident) => incident.fingerprint);
+  await Promise.all(
+    detected.map(async (incident) => {
+      const existing = await AnalyticsIncident.findOne({ fingerprint: incident.fingerprint })
+        .select("status acknowledgedAt acknowledgedByEmail")
+        .lean();
+      const remainsAcknowledged = existing?.status === "acknowledged";
+      return AnalyticsIncident.updateOne(
+        { fingerprint: incident.fingerprint },
+        {
+          $setOnInsert: { firstDetectedAt: now, occurrences: 0 },
+          $set: {
+            ...incident,
+            status: remainsAcknowledged ? "acknowledged" : "open",
+            lastDetectedAt: now,
+            resolvedAt: null,
+            resolvedByEmail: null,
+            acknowledgedAt: remainsAcknowledged ? existing.acknowledgedAt : null,
+            acknowledgedByEmail: remainsAcknowledged ? existing.acknowledgedByEmail : null,
+          },
+          $inc: { occurrences: 1 },
+        },
+        { upsert: true }
+      );
+    })
+  );
+
+  await AnalyticsIncident.updateMany(
+    {
+      status: { $in: ["open", "acknowledged"] },
+      fingerprint: { $nin: fingerprints },
+      source: { $in: ["server", "security", "forms", "mail", "analytics"] },
+    },
+    { $set: { status: "resolved", resolvedAt: now, resolvedByEmail: "automatic-recovery" } }
+  );
+};
+
+const runEvaluation = async () => {
+  const now = new Date();
+  const currentFrom = new Date(now.getTime() - 24 * 60 * 60_000);
+  const baselineFrom = new Date(currentFrom.getTime() - 7 * 24 * 60 * 60_000);
+  const [current, baseline, lastBrowserEvent] = await Promise.all([
+    aggregateWindow(currentFrom, now),
+    aggregateWindow(baselineFrom, currentFrom),
+    AnalyticsEvent.findOne().sort({ receivedAt: -1 }).select("receivedAt").lean(),
+  ]);
+  const detected = detectOperationalIncidents(current, baseline);
+
+  if (
+    lastBrowserEvent?.receivedAt &&
+    current.requests >= 10 &&
+    now.getTime() - new Date(lastBrowserEvent.receivedAt).getTime() > 24 * 60 * 60_000
+  ) {
+    const silentHours = round(
+      (now.getTime() - new Date(lastBrowserEvent.receivedAt).getTime()) / 3_600_000
+    );
+    detected.push({
+      fingerprint: "analytics:collection-stopped",
+      type: "analytics_collection_stopped",
+      source: "analytics",
+      severity: silentHours >= 72 ? "critical" : "warning",
+      title: "Browser analytics collection appears inactive",
+      message: `No consent-aware browser analytics event has been received for approximately ${silentHours} hours.`,
+      metric: "hoursSinceLastEvent",
+      currentValue: silentHours,
+      baselineValue: 0,
+      changePercent: 100,
+      threshold: 24,
+    });
+  }
+
+  await upsertDetectedIncidents(detected, now);
+  lastEvaluationAt = Date.now();
+  const incidents = await AnalyticsIncident.find({ status: { $in: ["open", "acknowledged"] } })
+    .sort({ severity: 1, lastDetectedAt: -1 })
+    .lean();
+  return incidents.map(serializeIncident);
+};
+
+export const evaluateAnalyticsAnomalies = async (force = false) => {
+  if (!force && Date.now() - lastEvaluationAt < 5 * 60_000) {
+    const incidents = await AnalyticsIncident.find({ status: { $in: ["open", "acknowledged"] } })
+      .sort({ lastDetectedAt: -1 })
+      .lean();
+    return incidents.map(serializeIncident);
+  }
+  if (!evaluationPromise) {
+    evaluationPromise = runEvaluation().finally(() => {
+      evaluationPromise = null;
+    });
+  }
+  return evaluationPromise;
+};
+
+export const getAnalyticsIncidentSummary = async () => {
+  const [open, critical, warning] = await Promise.all([
+    AnalyticsIncident.countDocuments({ status: { $in: ["open", "acknowledged"] } }),
+    AnalyticsIncident.countDocuments({ status: { $in: ["open", "acknowledged"] }, severity: "critical" }),
+    AnalyticsIncident.countDocuments({ status: { $in: ["open", "acknowledged"] }, severity: "warning" }),
+  ]);
+  return { open, critical, warning };
+};

--- a/src/services/analyticsReportService.ts
+++ b/src/services/analyticsReportService.ts
@@ -1,0 +1,1098 @@
+import AnalyticsEvent from "../models/AnalyticsEvent";
+import AnalyticsSession from "../models/AnalyticsSession";
+import AnalyticsServerMetric from "../models/AnalyticsServerMetric";
+import { getSearchConsoleReport } from "./searchConsoleService";
+import { evaluateAnalyticsAnomalies } from "./analyticsAnomalyService";
+
+type DateRange = {
+  from: Date;
+  to: Date;
+  previousFrom: Date;
+  previousTo: Date;
+  days: number;
+};
+
+type SummaryMetrics = {
+  visitors: number;
+  sessions: number;
+  pageViews: number;
+  activeVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  engagedSessions: number;
+  engagementRate: number;
+  bounceRate: number;
+  averageEngagementSeconds: number;
+  conversions: number;
+  convertedSessions: number;
+  conversionRate: number;
+  botSessions: number;
+  errors: number;
+};
+
+const humanSessionFilter = {
+  $or: [{ isBot: false }, { isBot: { $exists: false } }],
+};
+
+const humanEventFilter = {
+  $or: [{ "device.isBot": false }, { "device.isBot": { $exists: false } }],
+};
+
+const round = (value: number, precision = 1) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const percentage = (value: number, total: number) =>
+  total > 0 ? round((value / total) * 100) : 0;
+
+const changePercentage = (current: number, previous: number) => {
+  if (previous === 0) return current === 0 ? 0 : 100;
+  return round(((current - previous) / previous) * 100);
+};
+
+export const resolveAnalyticsDateRange = (query: Record<string, unknown>): DateRange => {
+  const requestedDays = Math.min(395, Math.max(1, Number(query.days) || 30));
+  const customFrom = typeof query.from === "string" ? new Date(query.from) : null;
+  const customTo = typeof query.to === "string" ? new Date(query.to) : null;
+  const to = customTo && !Number.isNaN(customTo.getTime()) ? customTo : new Date();
+  if (customTo && !Number.isNaN(customTo.getTime())) to.setHours(23, 59, 59, 999);
+
+  const earliestAllowed = new Date(to.getTime() - 395 * 24 * 60 * 60 * 1_000);
+  let from = customFrom && !Number.isNaN(customFrom.getTime())
+    ? customFrom
+    : new Date(to.getTime() - requestedDays * 24 * 60 * 60 * 1_000);
+  if (from < earliestAllowed) from = earliestAllowed;
+  if (from > to) from = new Date(to.getTime() - requestedDays * 24 * 60 * 60 * 1_000);
+  if (customFrom && !Number.isNaN(customFrom.getTime())) from.setHours(0, 0, 0, 0);
+
+  const duration = Math.max(1, to.getTime() - from.getTime());
+  const previousTo = new Date(from.getTime() - 1);
+  const previousFrom = new Date(previousTo.getTime() - duration);
+  const days = Math.max(1, Math.ceil(duration / (24 * 60 * 60 * 1_000)));
+
+  return { from, to, previousFrom, previousTo, days };
+};
+
+const getSummary = async (from: Date, to: Date, includeActive = false): Promise<SummaryMetrics> => {
+  const sessionRange = { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter };
+  const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+  const [
+    visitorIds,
+    sessions,
+    newVisitorIds,
+    engagementRows,
+    pageViews,
+    conversions,
+    convertedSessionIds,
+    botSessions,
+    errors,
+    activeVisitorIds,
+  ] = await Promise.all([
+    AnalyticsSession.distinct("visitorId", sessionRange),
+    AnalyticsSession.countDocuments(sessionRange),
+    AnalyticsSession.distinct("visitorId", { ...sessionRange, isNewVisitor: true }),
+    AnalyticsSession.aggregate([
+      { $match: sessionRange },
+      {
+        $group: {
+          _id: null,
+          totalEngagementMs: { $sum: "$engagementMs" },
+          engagedSessions: {
+            $sum: {
+              $cond: [
+                { $or: [{ $gte: ["$engagementMs", 10_000] }, { $gte: ["$pageViewCount", 2] }] },
+                1,
+                0,
+              ],
+            },
+          },
+        },
+      },
+    ]),
+    AnalyticsEvent.countDocuments({ ...eventRange, eventType: "page_view" }),
+    AnalyticsEvent.countDocuments({ ...eventRange, eventType: "conversion" }),
+    AnalyticsEvent.distinct("sessionId", { ...eventRange, eventType: "conversion" }),
+    AnalyticsSession.countDocuments({ startedAt: { $gte: from, $lte: to }, isBot: true }),
+    AnalyticsEvent.countDocuments({
+      ...eventRange,
+      eventType: { $in: ["error", "api_error", "not_found"] },
+    }),
+    includeActive
+      ? AnalyticsSession.distinct("visitorId", {
+          lastSeenAt: { $gte: new Date(Date.now() - 5 * 60 * 1_000) },
+          ...humanSessionFilter,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const visitors = visitorIds.length;
+  const newVisitors = newVisitorIds.length;
+  const engagedSessions = Number(engagementRows[0]?.engagedSessions || 0);
+  const totalEngagementMs = Number(engagementRows[0]?.totalEngagementMs || 0);
+
+  return {
+    visitors,
+    sessions,
+    pageViews,
+    activeVisitors: activeVisitorIds.length,
+    newVisitors,
+    returningVisitors: Math.max(0, visitors - newVisitors),
+    engagedSessions,
+    engagementRate: percentage(engagedSessions, sessions),
+    bounceRate: percentage(Math.max(0, sessions - engagedSessions), sessions),
+    averageEngagementSeconds: sessions > 0 ? round(totalEngagementMs / sessions / 1_000) : 0,
+    conversions,
+    convertedSessions: convertedSessionIds.length,
+    conversionRate: percentage(convertedSessionIds.length, sessions),
+    botSessions,
+    errors,
+  };
+};
+
+const getTimeline = async (from: Date, to: Date) => {
+  const [sessionRows, eventRows] = await Promise.all([
+    AnalyticsSession.aggregate([
+      { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+      {
+        $group: {
+          _id: { $dateToString: { format: "%Y-%m-%d", date: "$startedAt", timezone: "UTC" } },
+          sessions: { $sum: 1 },
+          visitors: { $addToSet: "$visitorId" },
+          newVisitors: { $sum: { $cond: ["$isNewVisitor", 1, 0] } },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]),
+    AnalyticsEvent.aggregate([
+      { $match: { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter } },
+      {
+        $group: {
+          _id: { $dateToString: { format: "%Y-%m-%d", date: "$occurredAt", timezone: "UTC" } },
+          pageViews: { $sum: { $cond: [{ $eq: ["$eventType", "page_view"] }, 1, 0] } },
+          conversions: { $sum: { $cond: [{ $eq: ["$eventType", "conversion"] }, 1, 0] } },
+          errors: {
+            $sum: {
+              $cond: [{ $in: ["$eventType", ["error", "api_error", "not_found"]] }, 1, 0],
+            },
+          },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]),
+  ]);
+
+  const rows = new Map<string, any>();
+  sessionRows.forEach((row) => {
+    rows.set(row._id, {
+      date: row._id,
+      visitors: row.visitors.length,
+      sessions: row.sessions,
+      newVisitors: row.newVisitors,
+      pageViews: 0,
+      conversions: 0,
+      errors: 0,
+    });
+  });
+  eventRows.forEach((row) => {
+    const current = rows.get(row._id) || {
+      date: row._id,
+      visitors: 0,
+      sessions: 0,
+      newVisitors: 0,
+      pageViews: 0,
+      conversions: 0,
+      errors: 0,
+    };
+    rows.set(row._id, {
+      ...current,
+      pageViews: row.pageViews,
+      conversions: row.conversions,
+      errors: row.errors,
+    });
+  });
+
+  const timeline = [];
+  const cursor = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()));
+  const lastDate = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()));
+  while (cursor <= lastDate) {
+    const date = cursor.toISOString().slice(0, 10);
+    timeline.push(
+      rows.get(date) || {
+        date,
+        visitors: 0,
+        sessions: 0,
+        newVisitors: 0,
+        pageViews: 0,
+        conversions: 0,
+        errors: 0,
+      }
+    );
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return timeline;
+};
+
+const getBreakdown = async (
+  field: string,
+  from: Date,
+  to: Date,
+  limit = 12,
+  extraMatch: Record<string, unknown> = {}
+) => {
+  const rows = await AnalyticsSession.aggregate([
+    { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter, ...extraMatch } },
+    { $group: { _id: { $ifNull: [`$${field}`, "Unknown"] }, count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+    { $limit: limit },
+  ]);
+  const total = rows.reduce((sum, row) => sum + Number(row.count || 0), 0);
+  return rows.map((row) => ({
+    name: String(row._id || "Unknown"),
+    count: Number(row.count || 0),
+    percentage: percentage(Number(row.count || 0), total),
+  }));
+};
+
+const getAudienceAndAcquisition = async (from: Date, to: Date) => {
+  const [countries, regions, locales, markets, devices, browsers, operatingSystems, sources, mediums, campaigns, referrers] =
+    await Promise.all([
+      getBreakdown("country", from, to, 15),
+      getBreakdown("region", from, to, 15),
+      getBreakdown("locale", from, to, 10),
+      getBreakdown("market", from, to, 10),
+      getBreakdown("deviceType", from, to, 10),
+      getBreakdown("browser", from, to, 10),
+      getBreakdown("os", from, to, 10),
+      getBreakdown("trafficSource", from, to, 15),
+      getBreakdown("trafficMedium", from, to, 12),
+      getBreakdown("campaign", from, to, 15, { campaign: { $nin: [null, ""] } }),
+      getBreakdown("referrerHost", from, to, 15, { referrerHost: { $nin: [null, ""] } }),
+    ]);
+
+  return {
+    audience: { countries, regions, locales, markets, devices, browsers, operatingSystems },
+    acquisition: { sources, mediums, campaigns, referrers },
+  };
+};
+
+const getContent = async (from: Date, to: Date) => {
+  const [pageRows, engagementRows, exitRows, landingRows, scrollRows, sessionCount] = await Promise.all([
+    AnalyticsEvent.aggregate([
+      {
+        $match: {
+          occurredAt: { $gte: from, $lte: to },
+          eventType: "page_view",
+          ...humanEventFilter,
+        },
+      },
+      {
+        $group: {
+          _id: "$path",
+          views: { $sum: 1 },
+          visitors: { $addToSet: "$visitorId" },
+          sessions: { $addToSet: "$sessionId" },
+        },
+      },
+      { $sort: { views: -1 } },
+      { $limit: 25 },
+    ]),
+    AnalyticsEvent.aggregate([
+      {
+        $match: {
+          occurredAt: { $gte: from, $lte: to },
+          eventType: "engagement",
+          "properties.durationMs": { $gt: 0 },
+          ...humanEventFilter,
+        },
+      },
+      { $group: { _id: "$path", engagementMs: { $sum: "$properties.durationMs" } } },
+    ]),
+    AnalyticsSession.aggregate([
+      { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+      {
+        $group: {
+          _id: "$exitPath",
+          exits: { $sum: 1 },
+          visitors: { $addToSet: "$visitorId" },
+        },
+      },
+      { $sort: { exits: -1 } },
+    ]),
+    AnalyticsSession.aggregate([
+      { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+      {
+        $group: {
+          _id: "$landingPath",
+          sessions: { $sum: 1 },
+          visitors: { $addToSet: "$visitorId" },
+        },
+      },
+      { $sort: { sessions: -1 } },
+      { $limit: 15 },
+    ]),
+    AnalyticsEvent.aggregate([
+      {
+        $match: {
+          occurredAt: { $gte: from, $lte: to },
+          eventType: "scroll",
+          eventName: "scroll_depth",
+          "properties.depth": { $in: [25, 50, 75, 90] },
+          ...humanEventFilter,
+        },
+      },
+      {
+        $group: {
+          _id: "$properties.depth",
+          events: { $sum: 1 },
+          sessions: { $addToSet: "$sessionId" },
+          visitors: { $addToSet: "$visitorId" },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]),
+    AnalyticsSession.countDocuments({
+      startedAt: { $gte: from, $lte: to },
+      ...humanSessionFilter,
+    }),
+  ]);
+
+  const engagement = new Map(engagementRows.map((row) => [row._id, Number(row.engagementMs || 0)]));
+  const exits = new Map(exitRows.map((row) => [row._id, Number(row.exits || 0)]));
+  const pages = pageRows.map((row) => ({
+    path: row._id || "/",
+    views: Number(row.views || 0),
+    visitors: row.visitors.length,
+    sessions: row.sessions.length,
+    exits: exits.get(row._id) || 0,
+    exitRate: percentage(exits.get(row._id) || 0, row.sessions.length),
+    averageEngagementSeconds:
+      row.sessions.length > 0 ? round((engagement.get(row._id) || 0) / row.sessions.length / 1_000) : 0,
+  }));
+
+  return {
+    pages,
+    insights: {
+      landingPages: landingRows.map((row) => ({
+        path: row._id || "/",
+        sessions: Number(row.sessions || 0),
+        visitors: row.visitors.length,
+        percentage: percentage(Number(row.sessions || 0), sessionCount),
+      })),
+      exitPages: exitRows.slice(0, 15).map((row) => ({
+        path: row._id || "/",
+        exits: Number(row.exits || 0),
+        visitors: row.visitors.length,
+        percentage: percentage(Number(row.exits || 0), sessionCount),
+      })),
+      scrollDepth: scrollRows.map((row) => ({
+        depth: Number(row._id || 0),
+        events: Number(row.events || 0),
+        sessions: row.sessions.length,
+        visitors: row.visitors.length,
+        percentage: percentage(row.sessions.length, sessionCount),
+      })),
+    },
+  };
+};
+
+const getConversions = async (from: Date, to: Date) => {
+  const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+  const [rows, formStarts, formAttempts, attributionRows, formRows] = await Promise.all([
+    AnalyticsEvent.aggregate([
+      { $match: { ...eventRange, eventType: "conversion" } },
+      {
+        $group: {
+          _id: { $ifNull: ["$properties.conversionType", "$eventName"] },
+          count: { $sum: 1 },
+          visitors: { $addToSet: "$visitorId" },
+          sessions: { $addToSet: "$sessionId" },
+        },
+      },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsEvent.countDocuments({ ...eventRange, eventType: "form", eventName: "form_start" }),
+    AnalyticsEvent.countDocuments({
+      ...eventRange,
+      eventType: "form",
+      eventName: "form_submit_attempt",
+    }),
+    AnalyticsSession.aggregate([
+      { $match: { startedAt: { $gte: from, $lte: to }, ...humanSessionFilter } },
+      {
+        $lookup: {
+          from: AnalyticsEvent.collection.name,
+          let: { currentSessionId: "$sessionId" },
+          pipeline: [
+            {
+              $match: {
+                eventType: "conversion",
+                occurredAt: { $gte: from, $lte: to },
+                ...humanEventFilter,
+                $expr: { $eq: ["$sessionId", "$$currentSessionId"] },
+              },
+            },
+            { $project: { _id: 1 } },
+          ],
+          as: "conversionEvents",
+        },
+      },
+      { $set: { conversionCount: { $size: "$conversionEvents" } } },
+      {
+        $facet: {
+          sources: [
+            {
+              $group: {
+                _id: { $ifNull: ["$trafficSource", "direct"] },
+                sessions: { $sum: 1 },
+                visitors: { $addToSet: "$visitorId" },
+                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                conversions: { $sum: "$conversionCount" },
+              },
+            },
+            { $sort: { convertedSessions: -1, sessions: -1 } },
+            { $limit: 12 },
+          ],
+          devices: [
+            {
+              $group: {
+                _id: { $ifNull: ["$deviceType", "unknown"] },
+                sessions: { $sum: 1 },
+                visitors: { $addToSet: "$visitorId" },
+                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                conversions: { $sum: "$conversionCount" },
+              },
+            },
+            { $sort: { convertedSessions: -1, sessions: -1 } },
+            { $limit: 8 },
+          ],
+          countries: [
+            {
+              $group: {
+                _id: { $ifNull: ["$country", "unknown"] },
+                sessions: { $sum: 1 },
+                visitors: { $addToSet: "$visitorId" },
+                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                conversions: { $sum: "$conversionCount" },
+              },
+            },
+            { $sort: { convertedSessions: -1, sessions: -1 } },
+            { $limit: 12 },
+          ],
+          landingPages: [
+            {
+              $group: {
+                _id: { $ifNull: ["$landingPath", "/"] },
+                sessions: { $sum: 1 },
+                visitors: { $addToSet: "$visitorId" },
+                convertedSessions: { $sum: { $cond: [{ $gt: ["$conversionCount", 0] }, 1, 0] } },
+                conversions: { $sum: "$conversionCount" },
+              },
+            },
+            { $sort: { convertedSessions: -1, sessions: -1 } },
+            { $limit: 12 },
+          ],
+        },
+      },
+    ]),
+    AnalyticsEvent.aggregate([
+      {
+        $match: {
+          ...eventRange,
+          eventType: "form",
+          eventName: { $in: ["form_start", "form_submit_attempt"] },
+          "properties.form": { $nin: [null, ""] },
+        },
+      },
+      {
+        $group: {
+          _id: { form: "$properties.form", eventName: "$eventName" },
+          events: { $sum: 1 },
+          sessions: { $addToSet: "$sessionId" },
+        },
+      },
+      { $sort: { events: -1 } },
+    ]),
+  ]);
+  const conversions = rows.map((row) => ({
+    name: String(row._id || "other"),
+    count: Number(row.count || 0),
+    visitors: row.visitors.length,
+    sessions: row.sessions.length,
+  }));
+
+  const mapAttribution = (attribution: any[] = []) => attribution.map((row) => ({
+    name: String(row._id || "unknown"),
+    sessions: Number(row.sessions || 0),
+    visitors: row.visitors.length,
+    convertedSessions: Number(row.convertedSessions || 0),
+    conversions: Number(row.conversions || 0),
+    conversionRate: percentage(Number(row.convertedSessions || 0), Number(row.sessions || 0)),
+  }));
+  const attribution = attributionRows[0] || {};
+  const forms = new Map<string, {
+    form: string;
+    startEvents: number;
+    attemptEvents: number;
+    startedSessions: number;
+    attemptedSessions: number;
+    attemptRate: number;
+  }>();
+  formRows.forEach((row) => {
+    const form = String(row._id?.form || "unknown");
+    const item = forms.get(form) || {
+      form,
+      startEvents: 0,
+      attemptEvents: 0,
+      startedSessions: 0,
+      attemptedSessions: 0,
+      attemptRate: 0,
+    };
+    if (row._id?.eventName === "form_start") {
+      item.startEvents = Number(row.events || 0);
+      item.startedSessions = row.sessions.length;
+    } else {
+      item.attemptEvents = Number(row.events || 0);
+      item.attemptedSessions = row.sessions.length;
+    }
+    forms.set(form, item);
+  });
+  const formItems = Array.from(forms.values())
+    .map((item) => ({
+      ...item,
+      attemptRate: percentage(item.attemptedSessions, item.startedSessions),
+    }))
+    .sort((left, right) => right.startedSessions - left.startedSessions);
+
+  return {
+    items: conversions,
+    funnel: {
+      formStarts,
+      formSubmitAttempts: formAttempts,
+      successfulConversions: conversions.reduce((sum, row) => sum + row.count, 0),
+    },
+    forms: formItems,
+    attribution: {
+      sources: mapAttribution(attribution.sources),
+      devices: mapAttribution(attribution.devices),
+      countries: mapAttribution(attribution.countries),
+      landingPages: mapAttribution(attribution.landingPages),
+    },
+  };
+};
+
+const percentile = (values: number[], target: number) => {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.max(0, Math.ceil(sorted.length * target) - 1)];
+};
+
+const getPerformance = async (from: Date, to: Date) => {
+  const events = await AnalyticsEvent.find({
+    occurredAt: { $gte: from, $lte: to },
+    eventType: "web_vital",
+    ...humanEventFilter,
+  })
+    .select("properties.metricName properties.metricValue properties.metricRating device.type")
+    .sort({ occurredAt: -1 })
+    .limit(50_000)
+    .lean();
+
+  const groups = new Map<string, { metric: string; device: string; values: number[]; ratings: string[] }>();
+  events.forEach((event: any) => {
+    const metric = String(event.properties?.metricName || "Unknown").toUpperCase();
+    const device = String(event.device?.type || "unknown");
+    const value = Number(event.properties?.metricValue);
+    if (!Number.isFinite(value)) return;
+    const key = `${metric}:${device}`;
+    const group = groups.get(key) || { metric, device, values: [], ratings: [] };
+    group.values.push(value);
+    group.ratings.push(String(event.properties?.metricRating || "unknown"));
+    groups.set(key, group);
+  });
+
+  const byDevice = Array.from(groups.values()).map((group) => ({
+    metric: group.metric,
+    device: group.device,
+    samples: group.values.length,
+    average: round(group.values.reduce((sum, value) => sum + value, 0) / group.values.length, 2),
+    p75: round(percentile(group.values, 0.75), 2),
+    good: group.ratings.filter((rating) => rating === "good").length,
+    needsImprovement: group.ratings.filter((rating) => rating === "needs-improvement").length,
+    poor: group.ratings.filter((rating) => rating === "poor").length,
+  }));
+
+  const overallGroups = new Map<string, { values: number[]; ratings: string[] }>();
+  Array.from(groups.values()).forEach((group) => {
+    const current = overallGroups.get(group.metric) || { values: [], ratings: [] };
+    current.values.push(...group.values);
+    current.ratings.push(...group.ratings);
+    overallGroups.set(group.metric, current);
+  });
+  const overall = Array.from(overallGroups.entries()).map(([metric, group]) => ({
+    metric,
+    samples: group.values.length,
+    average: round(group.values.reduce((sum, value) => sum + value, 0) / group.values.length, 2),
+    p75: round(percentile(group.values, 0.75), 2),
+    good: group.ratings.filter((rating) => rating === "good").length,
+    needsImprovement: group.ratings.filter((rating) => rating === "needs-improvement").length,
+    poor: group.ratings.filter((rating) => rating === "poor").length,
+  }));
+
+  return { overall, byDevice, sampleLimitReached: events.length === 50_000 };
+};
+
+const getServerBucketRange = (from: Date, to: Date) => {
+  const bucketFrom = new Date(from);
+  const startsInsideBucket =
+    bucketFrom.getUTCMinutes() !== 0 ||
+    bucketFrom.getUTCSeconds() !== 0 ||
+    bucketFrom.getUTCMilliseconds() !== 0;
+  bucketFrom.setUTCMinutes(0, 0, 0);
+  if (startsInsideBucket) bucketFrom.setUTCHours(bucketFrom.getUTCHours() + 1);
+  const bucketTo = new Date(to);
+  bucketTo.setUTCMinutes(0, 0, 0);
+  return { bucketFrom, bucketTo };
+};
+
+const getServerMetricTotals = async (from: Date, to: Date) => {
+  const { bucketFrom, bucketTo } = getServerBucketRange(from, to);
+  const rows = await AnalyticsServerMetric.aggregate([
+    { $match: { bucketStart: { $gte: bucketFrom, $lte: bucketTo } } },
+    {
+      $group: {
+        _id: null,
+        serverErrors: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        authDenied: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        formFailures: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+        spamBlocked: {
+          $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] },
+        },
+        botRequests: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+              "$count",
+              0,
+            ],
+          },
+        },
+      },
+    },
+  ]);
+
+  return {
+    serverErrors: Number(rows[0]?.serverErrors || 0),
+    authDenied: Number(rows[0]?.authDenied || 0),
+    formFailures: Number(rows[0]?.formFailures || 0),
+    spamBlocked: Number(rows[0]?.spamBlocked || 0),
+    botRequests: Number(rows[0]?.botRequests || 0),
+  };
+};
+
+const getServerHealth = async (from: Date, to: Date, previousFrom: Date, previousTo: Date) => {
+  const { bucketFrom, bucketTo } = getServerBucketRange(from, to);
+  const metricRange = { bucketStart: { $gte: bucketFrom, $lte: bucketTo } };
+  const [
+    apiRows,
+    statusRows,
+    failingRouteRows,
+    authRows,
+    formRows,
+    spamRows,
+    botRows,
+    timelineRows,
+    currentTotals,
+    previousTotals,
+    lastMetric,
+  ] = await Promise.all([
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "api_request" } },
+      {
+        $group: {
+          _id: null,
+          requests: { $sum: "$count" },
+          durationTotalMs: { $sum: "$durationTotalMs" },
+          durationMaxMs: { $max: "$durationMaxMs" },
+          successfulResponses: {
+            $sum: { $cond: [{ $and: [{ $gte: ["$statusCode", 200] }, { $lt: ["$statusCode", 400] }] }, "$count", 0] },
+          },
+          clientErrors: {
+            $sum: { $cond: [{ $and: [{ $gte: ["$statusCode", 400] }, { $lt: ["$statusCode", 500] }] }, "$count", 0] },
+          },
+          serverErrors: { $sum: { $cond: [{ $gte: ["$statusCode", 500] }, "$count", 0] } },
+          notFoundResponses: { $sum: { $cond: [{ $eq: ["$statusCode", 404] }, "$count", 0] } },
+          botRequests: { $sum: { $cond: ["$isBot", "$count", 0] } },
+        },
+      },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "api_request" } },
+      { $group: { _id: "$statusCode", count: { $sum: "$count" } } },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "api_request", statusCode: { $gte: 400 } } },
+      { $group: { _id: { route: "$route", statusCode: "$statusCode" }, count: { $sum: "$count" } } },
+      { $sort: { count: -1 } },
+      { $limit: 15 },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "auth_attempt" } },
+      { $group: { _id: { outcome: "$outcome", isBot: "$isBot" }, count: { $sum: "$count" } } },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "form_submission" } },
+      { $group: { _id: { category: "$category", outcome: "$outcome" }, count: { $sum: "$count" } } },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "spam_blocked" } },
+      { $group: { _id: "$category", count: { $sum: "$count" } } },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: { ...metricRange, metricType: "api_request", isBot: true } },
+      { $group: { _id: "$botName", count: { $sum: "$count" } } },
+      { $sort: { count: -1 } },
+      { $limit: 15 },
+    ]),
+    AnalyticsServerMetric.aggregate([
+      { $match: metricRange },
+      {
+        $group: {
+          _id: { $dateToString: { format: "%Y-%m-%d", date: "$bucketStart", timezone: "UTC" } },
+          requests: { $sum: { $cond: [{ $eq: ["$metricType", "api_request"] }, "$count", 0] } },
+          serverErrors: {
+            $sum: {
+              $cond: [
+                { $and: [{ $eq: ["$metricType", "api_request"] }, { $gte: ["$statusCode", 500] }] },
+                "$count",
+                0,
+              ],
+            },
+          },
+          notFound: {
+            $sum: {
+              $cond: [
+                { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$statusCode", 404] }] },
+                "$count",
+                0,
+              ],
+            },
+          },
+          authDenied: {
+            $sum: {
+              $cond: [
+                { $and: [{ $eq: ["$metricType", "auth_attempt"] }, { $eq: ["$outcome", "denied"] }] },
+                "$count",
+                0,
+              ],
+            },
+          },
+          formFailures: {
+            $sum: {
+              $cond: [
+                { $and: [{ $eq: ["$metricType", "form_submission"] }, { $eq: ["$outcome", "failed"] }] },
+                "$count",
+                0,
+              ],
+            },
+          },
+          spamBlocked: { $sum: { $cond: [{ $eq: ["$metricType", "spam_blocked"] }, "$count", 0] } },
+          botRequests: {
+            $sum: {
+              $cond: [
+                { $and: [{ $eq: ["$metricType", "api_request"] }, { $eq: ["$isBot", true] }] },
+                "$count",
+                0,
+              ],
+            },
+          },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]),
+    getServerMetricTotals(from, to),
+    getServerMetricTotals(previousFrom, previousTo),
+    AnalyticsServerMetric.findOne().sort({ lastOccurredAt: -1 }).select("lastOccurredAt").lean(),
+  ]);
+
+  const api = apiRows[0] || {};
+  const requests = Number(api.requests || 0);
+  const authSuccessful = authRows
+    .filter((row) => row._id.outcome === "success")
+    .reduce((sum, row) => sum + Number(row.count || 0), 0);
+  const authDenied = authRows
+    .filter((row) => row._id.outcome === "denied")
+    .reduce((sum, row) => sum + Number(row.count || 0), 0);
+  const authBotAttempts = authRows
+    .filter((row) => row._id.isBot)
+    .reduce((sum, row) => sum + Number(row.count || 0), 0);
+  const formItems = new Map<string, { type: string; attempts: number; successful: number; failed: number }>();
+  formRows.forEach((row) => {
+    const type = String(row._id.category || "other");
+    const current = formItems.get(type) || { type, attempts: 0, successful: 0, failed: 0 };
+    const count = Number(row.count || 0);
+    current.attempts += count;
+    if (row._id.outcome === "success") current.successful += count;
+    if (row._id.outcome === "failed") current.failed += count;
+    formItems.set(type, current);
+  });
+
+  return {
+    api: {
+      requests,
+      successfulResponses: Number(api.successfulResponses || 0),
+      clientErrors: Number(api.clientErrors || 0),
+      serverErrors: Number(api.serverErrors || 0),
+      notFoundResponses: Number(api.notFoundResponses || 0),
+      botRequests: Number(api.botRequests || 0),
+      observedAvailability: requests > 0
+        ? round(((requests - Number(api.serverErrors || 0)) / requests) * 100, 2)
+        : 0,
+      averageResponseMs: requests > 0 ? round(Number(api.durationTotalMs || 0) / requests) : 0,
+      maximumResponseMs: round(Number(api.durationMaxMs || 0)),
+      statuses: statusRows.map((row) => ({ status: Number(row._id || 0), count: Number(row.count || 0) })),
+      failingRoutes: failingRouteRows.map((row) => ({
+        route: String(row._id.route || "unknown"),
+        status: Number(row._id.statusCode || 0),
+        count: Number(row.count || 0),
+      })),
+    },
+    auth: {
+      attempts: authSuccessful + authDenied,
+      successful: authSuccessful,
+      denied: authDenied,
+      botAttempts: authBotAttempts,
+    },
+    forms: {
+      attempts: Array.from(formItems.values()).reduce((sum, item) => sum + item.attempts, 0),
+      successful: Array.from(formItems.values()).reduce((sum, item) => sum + item.successful, 0),
+      failed: Array.from(formItems.values()).reduce((sum, item) => sum + item.failed, 0),
+      byType: Array.from(formItems.values()),
+    },
+    spam: {
+      blocked: spamRows.reduce((sum, row) => sum + Number(row.count || 0), 0),
+      byRule: spamRows.map((row) => ({ name: String(row._id || "other"), count: Number(row.count || 0) })),
+    },
+    bots: botRows.map((row) => ({ name: String(row._id || "unknown"), count: Number(row.count || 0) })),
+    timeline: timelineRows.map((row) => ({
+      date: row._id,
+      requests: Number(row.requests || 0),
+      serverErrors: Number(row.serverErrors || 0),
+      notFound: Number(row.notFound || 0),
+      authDenied: Number(row.authDenied || 0),
+      formFailures: Number(row.formFailures || 0),
+      spamBlocked: Number(row.spamBlocked || 0),
+      botRequests: Number(row.botRequests || 0),
+    })),
+    comparison: Object.fromEntries(
+      Object.entries(currentTotals).map(([key, value]) => [
+        key,
+        changePercentage(Number(value || 0), Number(previousTotals[key as keyof typeof previousTotals] || 0)),
+      ])
+    ),
+    lastMetricAt: lastMetric?.lastOccurredAt || null,
+  };
+};
+
+const getHealth = async (from: Date, to: Date, previousFrom: Date, previousTo: Date) => {
+  const eventRange = { occurredAt: { $gte: from, $lte: to }, ...humanEventFilter };
+  const [errorRows, statusRows, botRows, lastEvent, server, incidents] = await Promise.all([
+    AnalyticsEvent.aggregate([
+      { $match: { ...eventRange, eventType: { $in: ["error", "api_error", "not_found"] } } },
+      { $group: { _id: "$eventName", count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsEvent.aggregate([
+      { $match: { ...eventRange, eventType: "api_error" } },
+      { $group: { _id: { $ifNull: ["$properties.statusCode", 0] }, count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ]),
+    AnalyticsSession.aggregate([
+      { $match: { startedAt: { $gte: from, $lte: to }, isBot: true } },
+      { $group: { _id: { $ifNull: ["$botName", "unknown"] }, count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: 15 },
+    ]),
+    AnalyticsEvent.findOne().sort({ receivedAt: -1 }).select("receivedAt eventName").lean(),
+    getServerHealth(from, to, previousFrom, previousTo),
+    evaluateAnalyticsAnomalies(),
+  ]);
+
+  return {
+    errorsByType: errorRows.map((row) => ({ name: row._id, count: Number(row.count || 0) })),
+    apiErrorsByStatus: statusRows.map((row) => ({ status: Number(row._id || 0), count: Number(row.count || 0) })),
+    bots: botRows.map((row) => ({ name: row._id, count: Number(row.count || 0) })),
+    lastEventAt: lastEvent?.receivedAt || null,
+    server,
+    incidents,
+  };
+};
+
+export const buildAnalyticsOverview = async (range: DateRange) => {
+  const [summary, previousSummary, timeline, audienceAcquisition, content, conversions, performance, health, seo] =
+    await Promise.all([
+      getSummary(range.from, range.to, true),
+      getSummary(range.previousFrom, range.previousTo),
+      getTimeline(range.from, range.to),
+      getAudienceAndAcquisition(range.from, range.to),
+      getContent(range.from, range.to),
+      getConversions(range.from, range.to),
+      getPerformance(range.from, range.to),
+      getHealth(range.from, range.to, range.previousFrom, range.previousTo),
+      getSearchConsoleReport(range.from, range.to),
+    ]);
+
+  const comparison = Object.fromEntries(
+    Object.entries(summary)
+      .filter(([key]) => key !== "activeVisitors")
+      .map(([key, value]) => [
+        key,
+        changePercentage(Number(value || 0), Number(previousSummary[key as keyof SummaryMetrics] || 0)),
+      ])
+  );
+
+  return {
+    range: {
+      from: range.from.toISOString(),
+      to: range.to.toISOString(),
+      previousFrom: range.previousFrom.toISOString(),
+      previousTo: range.previousTo.toISOString(),
+      days: range.days,
+    },
+    summary,
+    comparison,
+    timeline,
+    ...audienceAcquisition,
+    content: content.pages,
+    contentInsights: content.insights,
+    conversions,
+    performance,
+    health,
+    seo,
+  };
+};
+
+export const getRealtimeAnalytics = async () => {
+  const generatedAt = new Date();
+  const windowMinutes = 5;
+  const activeSince = new Date(generatedAt.getTime() - windowMinutes * 60_000);
+  const [result] = await AnalyticsSession.aggregate([
+    {
+      $match: {
+        lastSeenAt: { $gte: activeSince, $lte: generatedAt },
+        ...humanSessionFilter,
+      },
+    },
+    {
+      $facet: {
+        summary: [
+          {
+            $group: {
+              _id: null,
+              visitors: { $addToSet: "$visitorId" },
+              sessions: { $sum: 1 },
+              newVisitors: {
+                $addToSet: { $cond: ["$isNewVisitor", "$visitorId", null] },
+              },
+              lastActivityAt: { $max: "$lastSeenAt" },
+            },
+          },
+        ],
+        pages: [
+          {
+            $group: {
+              _id: { $ifNull: ["$exitPath", "/"] },
+              sessions: { $sum: 1 },
+              visitors: { $addToSet: "$visitorId" },
+            },
+          },
+          { $sort: { sessions: -1 } },
+          { $limit: 10 },
+        ],
+        countries: [
+          {
+            $group: {
+              _id: { $ifNull: ["$country", "unknown"] },
+              sessions: { $sum: 1 },
+              visitors: { $addToSet: "$visitorId" },
+            },
+          },
+          { $sort: { sessions: -1 } },
+          { $limit: 10 },
+        ],
+        devices: [
+          {
+            $group: {
+              _id: { $ifNull: ["$deviceType", "unknown"] },
+              sessions: { $sum: 1 },
+              visitors: { $addToSet: "$visitorId" },
+            },
+          },
+          { $sort: { sessions: -1 } },
+          { $limit: 6 },
+        ],
+        sources: [
+          {
+            $group: {
+              _id: { $ifNull: ["$trafficSource", "direct"] },
+              sessions: { $sum: 1 },
+              visitors: { $addToSet: "$visitorId" },
+            },
+          },
+          { $sort: { sessions: -1 } },
+          { $limit: 10 },
+        ],
+      },
+    },
+  ]);
+
+  const summary = result?.summary?.[0] || {};
+  const mapBreakdown = (rows: any[] = []) => rows.map((row) => ({
+    name: String(row._id || "unknown"),
+    sessions: Number(row.sessions || 0),
+    visitors: row.visitors.length,
+  }));
+
+  return {
+    generatedAt,
+    activeSince,
+    windowMinutes,
+    activeVisitors: summary.visitors?.length || 0,
+    activeSessions: Number(summary.sessions || 0),
+    newVisitors: Array.isArray(summary.newVisitors)
+      ? summary.newVisitors.filter(Boolean).length
+      : 0,
+    lastActivityAt: summary.lastActivityAt || null,
+    pages: mapBreakdown(result?.pages),
+    countries: mapBreakdown(result?.countries),
+    devices: mapBreakdown(result?.devices),
+    sources: mapBreakdown(result?.sources),
+  };
+};

--- a/src/services/analyticsServerMetricService.ts
+++ b/src/services/analyticsServerMetricService.ts
@@ -1,0 +1,65 @@
+import AnalyticsServerMetric, {
+  AnalyticsServerMetricType,
+} from "../models/AnalyticsServerMetric";
+
+export interface RecordServerMetricInput {
+  metricType: AnalyticsServerMetricType;
+  route?: string;
+  method?: string;
+  statusCode?: number;
+  outcome?: string;
+  category?: string;
+  country?: string;
+  isBot?: boolean;
+  botName?: string;
+  durationMs?: number;
+  occurredAt?: Date;
+}
+
+const cleanDimension = (value: unknown, fallback: string, maxLength: number) => {
+  const cleaned = String(value || "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+  return cleaned || fallback;
+};
+
+const getHourBucket = (value: Date) => {
+  const bucket = new Date(value);
+  bucket.setUTCMinutes(0, 0, 0);
+  return bucket;
+};
+
+export const recordServerMetric = async (input: RecordServerMetricInput): Promise<void> => {
+  try {
+    const occurredAt = input.occurredAt || new Date();
+    const durationMs = Math.max(0, Math.min(3_600_000, Math.round(Number(input.durationMs) || 0)));
+    const dimensions = {
+      bucketStart: getHourBucket(occurredAt),
+      metricType: input.metricType,
+      route: cleanDimension(input.route, "unknown", 180),
+      method: cleanDimension(input.method, "UNKNOWN", 12).toUpperCase(),
+      statusCode: Math.max(0, Math.min(999, Math.round(Number(input.statusCode) || 0))),
+      outcome: cleanDimension(input.outcome, "unknown", 40).toLowerCase(),
+      category: cleanDimension(input.category, "general", 80).toLowerCase(),
+      country: cleanDimension(input.country, "unknown", 4).toUpperCase(),
+      isBot: Boolean(input.isBot),
+      botName: cleanDimension(input.botName, "none", 40).toLowerCase(),
+    };
+
+    await AnalyticsServerMetric.updateOne(
+      dimensions,
+      {
+        $setOnInsert: dimensions,
+        $set: { lastOccurredAt: occurredAt },
+        $inc: { count: 1, durationTotalMs: durationMs },
+        $max: { durationMaxMs: durationMs },
+      },
+      { upsert: true }
+    );
+  } catch (error) {
+    // Analytics must never make a business request fail.
+    console.error("Server analytics metric failed:", (error as Error).message);
+  }
+};

--- a/src/services/emailSyncService.ts
+++ b/src/services/emailSyncService.ts
@@ -7,6 +7,7 @@ import {
   isSpamMessage,
   spamMessageMongoFilter,
 } from "../utils/emailFilters";
+import { recordServerMetric } from "./analyticsServerMetricService";
 
 interface MailboxConfig {
   key: string;
@@ -244,6 +245,22 @@ const syncFolder = async (
       } else {
         await EmailMessage.create(payload);
         result.imported += 1;
+        if (isSpam) {
+          const folderClassified =
+            String(folder.specialUse || "").toLowerCase() === "\\junk" ||
+            /(^|[\/._ -])(spam|junk|promotions?)([\/._ -]|$)/i.test(folder.path);
+          void recordServerMetric({
+            metricType: "spam_blocked",
+            route: "mailbox_sync",
+            method: "SYNC",
+            outcome: "filtered",
+            category: isDmarcReport(spamInput)
+              ? "dmarc_report"
+              : folderClassified
+                ? "mailbox_folder"
+                : "content_rule",
+          });
+        }
       }
     } catch {
       result.skipped += 1;

--- a/src/services/searchConsoleService.ts
+++ b/src/services/searchConsoleService.ts
@@ -1,0 +1,315 @@
+import crypto from "crypto";
+import SearchConsoleCache from "../models/SearchConsoleCache";
+
+const SEARCH_CONSOLE_SCOPE = "https://www.googleapis.com/auth/webmasters.readonly";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SEARCH_ANALYTICS_URL = "https://www.googleapis.com/webmasters/v3/sites";
+const DEFAULT_CACHE_MINUTES = 360;
+
+type SearchDimension = "date" | "query" | "page" | "country" | "device";
+
+interface SearchAnalyticsRow {
+  keys?: string[];
+  clicks?: number;
+  impressions?: number;
+  ctr?: number;
+  position?: number;
+}
+
+interface SearchMetricRow {
+  name: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface PropertyResult {
+  siteUrl: string;
+  summary: SearchMetricRow;
+  timeline: SearchMetricRow[];
+  queries: SearchMetricRow[];
+  pages: SearchMetricRow[];
+  countries: SearchMetricRow[];
+  devices: SearchMetricRow[];
+}
+
+let accessTokenCache: { token: string; expiresAt: number } | null = null;
+
+const round = (value: number, precision = 2) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const base64Url = (value: string | Buffer) =>
+  Buffer.from(value)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+const getPrivateKey = () => {
+  const plain = String(process.env.GSC_SERVICE_ACCOUNT_PRIVATE_KEY || "").trim();
+  const encoded = String(process.env.GSC_SERVICE_ACCOUNT_PRIVATE_KEY_BASE64 || "").trim();
+  if (plain) return plain.replace(/\\n/g, "\n");
+  if (!encoded) return "";
+  try {
+    return Buffer.from(encoded, "base64").toString("utf8").replace(/\\n/g, "\n");
+  } catch {
+    return "";
+  }
+};
+
+const getSiteUrls = () =>
+  Array.from(
+    new Set(
+      String(process.env.GSC_SITE_URLS || "")
+        .split(/[;,\n]/)
+        .map((value) => value.trim())
+        .filter(Boolean)
+    )
+  );
+
+const getConfiguration = () => {
+  const clientEmail = String(process.env.GSC_SERVICE_ACCOUNT_EMAIL || "").trim();
+  const privateKey = getPrivateKey();
+  const siteUrls = getSiteUrls();
+  const missing = [];
+  if (!clientEmail) missing.push("GSC_SERVICE_ACCOUNT_EMAIL");
+  if (!privateKey) missing.push("GSC_SERVICE_ACCOUNT_PRIVATE_KEY_BASE64");
+  if (!siteUrls.length) missing.push("GSC_SITE_URLS");
+  return { clientEmail, privateKey, siteUrls, missing };
+};
+
+const fetchWithTimeout = async (url: string, init: RequestInit, timeoutMs = 15_000) => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const getAccessToken = async (clientEmail: string, privateKey: string) => {
+  if (accessTokenCache && accessTokenCache.expiresAt > Date.now() + 60_000) {
+    return accessTokenCache.token;
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1_000);
+  const header = base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claim = base64Url(
+    JSON.stringify({
+      iss: clientEmail,
+      scope: SEARCH_CONSOLE_SCOPE,
+      aud: TOKEN_URL,
+      iat: issuedAt - 30,
+      exp: issuedAt + 3_600,
+    })
+  );
+  const unsignedToken = `${header}.${claim}`;
+  const signature = crypto.sign("RSA-SHA256", Buffer.from(unsignedToken), privateKey);
+  const assertion = `${unsignedToken}.${base64Url(signature)}`;
+  const response = await fetchWithTimeout(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  const payload = await response.json() as { access_token?: string; expires_in?: number; error_description?: string };
+  if (!response.ok || !payload.access_token) {
+    throw new Error(payload.error_description || `Google OAuth failed (${response.status}).`);
+  }
+  accessTokenCache = {
+    token: payload.access_token,
+    expiresAt: Date.now() + Math.max(300, Number(payload.expires_in || 3_600)) * 1_000,
+  };
+  return payload.access_token;
+};
+
+const querySearchAnalytics = async (
+  accessToken: string,
+  siteUrl: string,
+  startDate: string,
+  endDate: string,
+  dimensions: SearchDimension[],
+  rowLimit: number
+) => {
+  const response = await fetchWithTimeout(
+    `${SEARCH_ANALYTICS_URL}/${encodeURIComponent(siteUrl)}/searchAnalytics/query`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        startDate,
+        endDate,
+        dimensions,
+        type: "web",
+        aggregationType: dimensions.includes("page") ? "auto" : "byProperty",
+        dataState: "final",
+        rowLimit,
+        startRow: 0,
+      }),
+    }
+  );
+  const payload = await response.json() as {
+    rows?: SearchAnalyticsRow[];
+    error?: { message?: string };
+  };
+  if (!response.ok) {
+    throw new Error(payload.error?.message || `Search Console query failed (${response.status}).`);
+  }
+  return payload.rows || [];
+};
+
+const normalizeRow = (row: SearchAnalyticsRow, name: string): SearchMetricRow => ({
+  name,
+  clicks: Math.round(Number(row.clicks || 0)),
+  impressions: Math.round(Number(row.impressions || 0)),
+  ctr: round(Number(row.ctr || 0) * 100),
+  position: round(Number(row.position || 0)),
+});
+
+const queryProperty = async (
+  accessToken: string,
+  siteUrl: string,
+  startDate: string,
+  endDate: string
+): Promise<PropertyResult> => {
+  const [summaryRows, timelineRows, queryRows, pageRows, countryRows, deviceRows] = await Promise.all([
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, [], 1),
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["date"], 500),
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["query"], 100),
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["page"], 100),
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["country"], 50),
+    querySearchAnalytics(accessToken, siteUrl, startDate, endDate, ["device"], 10),
+  ]);
+
+  return {
+    siteUrl,
+    summary: normalizeRow(summaryRows[0] || {}, siteUrl),
+    timeline: timelineRows.map((row) => normalizeRow(row, row.keys?.[0] || "unknown")),
+    queries: queryRows.map((row) => normalizeRow(row, row.keys?.[0] || "Unknown query")),
+    pages: pageRows.map((row) => normalizeRow(row, row.keys?.[0] || "/")),
+    countries: countryRows.map((row) => normalizeRow(row, row.keys?.[0] || "unknown")),
+    devices: deviceRows.map((row) => normalizeRow(row, row.keys?.[0] || "unknown")),
+  };
+};
+
+const mergeRows = (rows: SearchMetricRow[], sortBy: "name" | "clicks" = "clicks") => {
+  const merged = new Map<string, { name: string; clicks: number; impressions: number; positionWeight: number }>();
+  rows.forEach((row) => {
+    const current = merged.get(row.name) || { name: row.name, clicks: 0, impressions: 0, positionWeight: 0 };
+    current.clicks += row.clicks;
+    current.impressions += row.impressions;
+    current.positionWeight += row.position * row.impressions;
+    merged.set(row.name, current);
+  });
+  const result = Array.from(merged.values()).map((row) => ({
+    name: row.name,
+    clicks: row.clicks,
+    impressions: row.impressions,
+    ctr: row.impressions > 0 ? round((row.clicks / row.impressions) * 100) : 0,
+    position: row.impressions > 0 ? round(row.positionWeight / row.impressions) : 0,
+  }));
+  return result.sort((left, right) =>
+    sortBy === "name" ? left.name.localeCompare(right.name) : right.clicks - left.clicks || right.impressions - left.impressions
+  );
+};
+
+const buildMergedReport = (properties: PropertyResult[], startDate: string, endDate: string) => {
+  const propertySummaries = properties.map((property) => property.summary);
+  const totalClicks = propertySummaries.reduce((sum, row) => sum + row.clicks, 0);
+  const totalImpressions = propertySummaries.reduce((sum, row) => sum + row.impressions, 0);
+  const positionWeight = propertySummaries.reduce(
+    (sum, row) => sum + row.position * row.impressions,
+    0
+  );
+  const timeline = mergeRows(properties.flatMap((property) => property.timeline), "name");
+  return {
+    configured: true,
+    status: "connected",
+    startDate,
+    endDate,
+    dataThrough: timeline.length ? timeline[timeline.length - 1].name : null,
+    summary: {
+      clicks: totalClicks,
+      impressions: totalImpressions,
+      ctr: totalImpressions > 0 ? round((totalClicks / totalImpressions) * 100) : 0,
+      position: totalImpressions > 0 ? round(positionWeight / totalImpressions) : 0,
+    },
+    timeline,
+    queries: mergeRows(properties.flatMap((property) => property.queries)).slice(0, 100),
+    pages: mergeRows(properties.flatMap((property) => property.pages)).slice(0, 100),
+    countries: mergeRows(properties.flatMap((property) => property.countries)).slice(0, 50),
+    devices: mergeRows(properties.flatMap((property) => property.devices)).slice(0, 10),
+    properties: properties.map((property) => ({ siteUrl: property.siteUrl, ...property.summary })),
+  };
+};
+
+const toDateOnly = (value: Date) => value.toISOString().slice(0, 10);
+
+export const getSearchConsoleReport = async (from: Date, to: Date) => {
+  const configuration = getConfiguration();
+  if (configuration.missing.length) {
+    return {
+      configured: false,
+      status: "not_configured",
+      missing: configuration.missing,
+      message: "Google Search Console is ready but its server credentials are not configured yet.",
+    };
+  }
+
+  const startDate = toDateOnly(from);
+  const endDate = toDateOnly(to);
+  const cacheKey = crypto
+    .createHash("sha256")
+    .update(`${[...configuration.siteUrls].sort().join("|")}:${startDate}:${endDate}:web:v1`)
+    .digest("hex");
+  const cached = await SearchConsoleCache.findOne({ cacheKey }).lean();
+  if (cached && cached.expiresAt.getTime() > Date.now()) {
+    return { ...cached.payload, cached: true, fetchedAt: cached.fetchedAt };
+  }
+
+  try {
+    const accessToken = await getAccessToken(configuration.clientEmail, configuration.privateKey);
+    const properties = await Promise.all(
+      configuration.siteUrls.map((siteUrl) => queryProperty(accessToken, siteUrl, startDate, endDate))
+    );
+    const report = buildMergedReport(properties, startDate, endDate);
+    const fetchedAt = new Date();
+    const configuredMinutes = Number(process.env.GSC_CACHE_MINUTES || DEFAULT_CACHE_MINUTES);
+    const cacheMinutes = Number.isFinite(configuredMinutes)
+      ? Math.max(15, Math.min(1_440, configuredMinutes))
+      : DEFAULT_CACHE_MINUTES;
+    const expiresAt = new Date(fetchedAt.getTime() + cacheMinutes * 60_000);
+    const deleteAfter = new Date(fetchedAt.getTime() + 7 * 24 * 60 * 60_000);
+    await SearchConsoleCache.updateOne(
+      { cacheKey },
+      { $set: { payload: report, fetchedAt, expiresAt, deleteAfter } },
+      { upsert: true }
+    );
+    return { ...report, cached: false, fetchedAt };
+  } catch (error) {
+    if (cached) {
+      return {
+        ...cached.payload,
+        cached: true,
+        stale: true,
+        fetchedAt: cached.fetchedAt,
+        warning: (error as Error).message.slice(0, 240),
+      };
+    }
+    return {
+      configured: true,
+      status: "error",
+      message: (error as Error).message.slice(0, 240),
+      properties: configuration.siteUrls.map((siteUrl) => ({ siteUrl })),
+    };
+  }
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
   "version": 2,
   "builds": [{ "src": "src/server.ts", "use": "@vercel/node" }],
-  "routes": [{ "src": "/(.*)", "dest": "src/server.ts" }]
+  "routes": [{ "src": "/(.*)", "dest": "src/server.ts" }],
+  "crons": [
+    {
+      "path": "/api/health/monitor",
+      "schedule": "0 6 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## What changed

- Adds protected analytics overview, realtime and incident APIs.
- Adds audience, acquisition, content, conversion attribution, Core Web Vitals, technical health and security reports.
- Adds Google Search Console read-only reporting with multi-property caching and stale fallback.
- Adds hourly server telemetry, anomaly detection and incident lifecycle management.
- Adds liveness, readiness and secured monitoring endpoints plus the Vercel daily cron.
- Records newly classified mail spam in security metrics and removes sensitive token-prefix logging.

## Why

Creativa Poeta needs privacy-safe owner reporting and actionable monitoring across website usage, SEO, API health, forms, authentication, bots and spam.

## Impact

Analytics routes require `analytics:read`. Search Console and cron integrations use environment variables only; no secret is committed.

## Validation

- Backend TypeScript production build
- `git diff --check`
- Local health smoke tests for live, ready and secured monitor behavior
