### PR TITLE
Fix analytics incident evaluation

### DIFF
--- a/dist/services/analyticsAnomalyService.js
+++ b/dist/services/analyticsAnomalyService.js
@@ -238,7 +238,7 @@ const upsertDetectedIncidents = async (detected, now) => {
             .lean();
         const remainsAcknowledged = (existing === null || existing === void 0 ? void 0 : existing.status) === "acknowledged";
         return AnalyticsIncident_1.default.updateOne({ fingerprint: incident.fingerprint }, {
-            $setOnInsert: { firstDetectedAt: now, occurrences: 0 },
+            $setOnInsert: { firstDetectedAt: now },
             $set: {
                 ...incident,
                 status: remainsAcknowledged ? "acknowledged" : "open",

--- a/dist/services/searchConsoleService.js
+++ b/dist/services/searchConsoleService.js
@@ -213,8 +213,28 @@ const getSearchConsoleReport = async (from, to) => {
     }
     try {
         const accessToken = await getAccessToken(configuration.clientEmail, configuration.privateKey);
-        const properties = await Promise.all(configuration.siteUrls.map((siteUrl) => queryProperty(accessToken, siteUrl, startDate, endDate)));
-        const report = buildMergedReport(properties, startDate, endDate);
+        const propertyResults = await Promise.allSettled(configuration.siteUrls.map((siteUrl) => queryProperty(accessToken, siteUrl, startDate, endDate)));
+        const properties = propertyResults.flatMap((result) => result.status === "fulfilled" ? [result.value] : []);
+        const propertyErrors = propertyResults.flatMap((result, index) => {
+            var _a;
+            return result.status === "rejected"
+                ? [{
+                        siteUrl: configuration.siteUrls[index],
+                        message: String(((_a = result.reason) === null || _a === void 0 ? void 0 : _a.message) || result.reason || "Search Console query failed.").slice(0, 240),
+                    }]
+                : [];
+        });
+        if (!properties.length) {
+            throw new Error(propertyErrors.map((item) => `${item.siteUrl}: ${item.message}`).join(" | ") ||
+                "No Search Console property could be queried.");
+        }
+        const report = {
+            ...buildMergedReport(properties, startDate, endDate),
+            propertyErrors,
+            warning: propertyErrors.length
+                ? `${propertyErrors.length} Search Console propert${propertyErrors.length === 1 ? "y" : "ies"} could not be refreshed.`
+                : undefined,
+        };
         const fetchedAt = new Date();
         const configuredMinutes = Number(process.env.GSC_CACHE_MINUTES || DEFAULT_CACHE_MINUTES);
         const cacheMinutes = Number.isFinite(configuredMinutes)

--- a/src/services/analyticsAnomalyService.ts
+++ b/src/services/analyticsAnomalyService.ts
@@ -291,7 +291,7 @@ const upsertDetectedIncidents = async (detected: DetectedIncident[], now: Date) 
       return AnalyticsIncident.updateOne(
         { fingerprint: incident.fingerprint },
         {
-          $setOnInsert: { firstDetectedAt: now, occurrences: 0 },
+          $setOnInsert: { firstDetectedAt: now },
           $set: {
             ...incident,
             status: remainsAcknowledged ? "acknowledged" : "open",

--- a/src/services/searchConsoleService.ts
+++ b/src/services/searchConsoleService.ts
@@ -278,10 +278,33 @@ export const getSearchConsoleReport = async (from: Date, to: Date) => {
 
   try {
     const accessToken = await getAccessToken(configuration.clientEmail, configuration.privateKey);
-    const properties = await Promise.all(
+    const propertyResults = await Promise.allSettled(
       configuration.siteUrls.map((siteUrl) => queryProperty(accessToken, siteUrl, startDate, endDate))
     );
-    const report = buildMergedReport(properties, startDate, endDate);
+    const properties = propertyResults.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : []
+    );
+    const propertyErrors = propertyResults.flatMap((result, index) =>
+      result.status === "rejected"
+        ? [{
+            siteUrl: configuration.siteUrls[index],
+            message: String(result.reason?.message || result.reason || "Search Console query failed.").slice(0, 240),
+          }]
+        : []
+    );
+    if (!properties.length) {
+      throw new Error(
+        propertyErrors.map((item) => `${item.siteUrl}: ${item.message}`).join(" | ") ||
+          "No Search Console property could be queried."
+      );
+    }
+    const report = {
+      ...buildMergedReport(properties, startDate, endDate),
+      propertyErrors,
+      warning: propertyErrors.length
+        ? `${propertyErrors.length} Search Console propert${propertyErrors.length === 1 ? "y" : "ies"} could not be refreshed.`
+        : undefined,
+    };
     const fetchedAt = new Date();
     const configuredMinutes = Number(process.env.GSC_CACHE_MINUTES || DEFAULT_CACHE_MINUTES);
     const cacheMinutes = Number.isFinite(configuredMinutes)


### PR DESCRIPTION
Fixes the MongoDB update conflict on the analytics incident occurrences field that prevented the Website Analytics report from loading. Also makes Search Console aggregation tolerate one failing property and return partial results with explicit property errors.